### PR TITLE
Push notifications scheduled from background refreshing.

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		00B4D6BD24178DE300ED8318 /* HelperFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BBD806237D755600EBF5E6 /* HelperFunctions.swift */; };
 		00B4D6F6241B778D00ED8318 /* BackgroundTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B4D6F5241B778D00ED8318 /* BackgroundTaskManager.swift */; };
 		00B4D6F8241B77A900ED8318 /* NodeSyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B4D6F7241B77A900ED8318 /* NodeSyncOperation.swift */; };
+		00B4D6FA241B910200ED8318 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B4D6F9241B910200ED8318 /* NotificationManager.swift */; };
 		00BBD801237C5B5200EBF5E6 /* CommandLineArgs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BBD800237C5B5200EBF5E6 /* CommandLineArgs.swift */; };
 		00BBD802237C5B5200EBF5E6 /* CommandLineArgs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BBD800237C5B5200EBF5E6 /* CommandLineArgs.swift */; };
 		00BBD803237C5B5200EBF5E6 /* CommandLineArgs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BBD800237C5B5200EBF5E6 /* CommandLineArgs.swift */; };
@@ -286,6 +287,12 @@
 		00DC2E22238554FD00036DDC /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 00DC2E21238554FD00036DDC /* libsqlite3.tbd */; };
 		00DC2E242385559C00036DDC /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 00DC2E232385559C00036DDC /* libsqlite3.tbd */; };
 		00DC2E25238555A200036DDC /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 00DC2E232385559C00036DDC /* libsqlite3.tbd */; };
+		00DD160B241CCE0600C955B4 /* TariSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DD160A241CCE0600C955B4 /* TariSettings.swift */; };
+		00DD160C241CCE5B00C955B4 /* TariSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DD160A241CCE0600C955B4 /* TariSettings.swift */; };
+		00DD160D241CCE5B00C955B4 /* TariSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DD160A241CCE0600C955B4 /* TariSettings.swift */; };
+		00DD160F241CD41D00C955B4 /* BaseNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DD160E241CD41D00C955B4 /* BaseNode.swift */; };
+		00DD1610241CD42500C955B4 /* BaseNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DD160E241CD41D00C955B4 /* BaseNode.swift */; };
+		00DD1611241CD42500C955B4 /* BaseNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DD160E241CD41D00C955B4 /* BaseNode.swift */; };
 		00E2BC9B236AAFB100C2A105 /* TransactionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E2BC9A236AAFB100C2A105 /* TransactionsTableViewController.swift */; };
 		00E2BC9C236AAFB100C2A105 /* TransactionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E2BC9A236AAFB100C2A105 /* TransactionsTableViewController.swift */; };
 		00E2BC9D236AAFB100C2A105 /* TransactionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E2BC9A236AAFB100C2A105 /* TransactionsTableViewController.swift */; };
@@ -495,6 +502,8 @@
 		00B4D6BA2417894800ED8318 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SnapshotHelper.swift; path = fastlane/SnapshotHelper.swift; sourceTree = SOURCE_ROOT; };
 		00B4D6F5241B778D00ED8318 /* BackgroundTaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskManager.swift; sourceTree = "<group>"; };
 		00B4D6F7241B77A900ED8318 /* NodeSyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeSyncOperation.swift; sourceTree = "<group>"; };
+		00B4D6F9241B910200ED8318 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		00B4D6FB241B97CD00ED8318 /* Tari.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tari.entitlements; sourceTree = "<group>"; };
 		00BBD7EE237B014100EBF5E6 /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/lib/libc++.tbd"; sourceTree = DEVELOPER_DIR; };
 		00BBD7F6237B05A900EBF5E6 /* MobileWalletTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MobileWalletTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		00BBD800237C5B5200EBF5E6 /* CommandLineArgs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandLineArgs.swift; sourceTree = "<group>"; };
@@ -515,6 +524,8 @@
 		00C185C52390221A0096984E /* DevelopmentUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevelopmentUI.swift; sourceTree = "<group>"; };
 		00DC2E21238554FD00036DDC /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		00DC2E232385559C00036DDC /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
+		00DD160A241CCE0600C955B4 /* TariSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TariSettings.swift; sourceTree = "<group>"; };
+		00DD160E241CD41D00C955B4 /* BaseNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNode.swift; sourceTree = "<group>"; };
 		00E2BC9A236AAFB100C2A105 /* TransactionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsTableViewController.swift; sourceTree = "<group>"; };
 		00E2BCA7236AB28200C2A105 /* TransactionTableTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionTableTableViewCell.swift; sourceTree = "<group>"; };
 		00E2BCA8236AB28200C2A105 /* TransactionTableTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TransactionTableTableViewCell.xib; sourceTree = "<group>"; };
@@ -722,6 +733,7 @@
 				00262EAD236F013500A6C8A0 /* Extensions */,
 				00262EB3236F024400A6C8A0 /* Theme.swift */,
 				00BBD800237C5B5200EBF5E6 /* CommandLineArgs.swift */,
+				00B4D6F9241B910200ED8318 /* NotificationManager.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -751,6 +763,7 @@
 				004277FA23E1A61F00AE7BD9 /* ErrorDescriptions.swift */,
 				0091D4A623ED879E004BF7F7 /* Signature.swift */,
 				0091D4AA23ED87BE004BF7F7 /* TestnetKeyServer.swift */,
+				00DD160E241CD41D00C955B4 /* BaseNode.swift */,
 			);
 			name = Utils;
 			path = Wrappers/Utils;
@@ -961,6 +974,7 @@
 		00E491982366E08B007B332D /* MobileWallet */ = {
 			isa = PBXGroup;
 			children = (
+				00B4D6FB241B97CD00ED8318 /* Tari.entitlements */,
 				4C2C95B8237959B3005058AB /* MobileWallet-bridging-header.h */,
 				4C2C95AA2379554B005058AB /* TariLib */,
 				00E491992366E08B007B332D /* AppDelegate.swift */,
@@ -1036,6 +1050,7 @@
 				4C2C95C223796184005058AB /* libzmq.a */,
 				4C2C95AF23795919005058AB /* libwallet_ffi.a */,
 				009BF8AB237ABB4700C02E44 /* TariLib.swift */,
+				00DD160A241CCE0600C955B4 /* TariSettings.swift */,
 				00BCE485240D5A9E00B181F3 /* Tor */,
 				006D211B23CEDEEE007D1C10 /* Utils */,
 				00BBD80C237DA04300EBF5E6 /* Wrappers */,
@@ -1623,6 +1638,7 @@
 				001F6CE42380253B00FA7002 /* Contact.swift in Sources */,
 				00325ECA239E4A1000F76918 /* FadedOverlayView.swift in Sources */,
 				00262EB9236F35CD00A6C8A0 /* DummyTransaction.swift in Sources */,
+				00DD160F241CD41D00C955B4 /* BaseNode.swift in Sources */,
 				00A6779E23743696001A853E /* TransactionViewController.swift in Sources */,
 				00BCE482240D5A9700B181F3 /* OnionConnector.swift in Sources */,
 				004997AF2382E938000A0B7D /* PendingOutboundTransaction.swift in Sources */,
@@ -1632,8 +1648,10 @@
 				004997BB2382F5ED000A0B7D /* WalletTestDataExtension.swift in Sources */,
 				00E2BC9B236AAFB100C2A105 /* TransactionsTableViewController.swift in Sources */,
 				00E2BCBA236B5BE800C2A105 /* ActionButton.swift in Sources */,
+				00B4D6FA241B910200ED8318 /* NotificationManager.swift in Sources */,
 				00BBD801237C5B5200EBF5E6 /* CommandLineArgs.swift in Sources */,
 				4CD20A362407967B007B64D8 /* TransportType.swift in Sources */,
+				00DD160B241CCE0600C955B4 /* TariSettings.swift in Sources */,
 				00B4D6F6241B778D00ED8318 /* BackgroundTaskManager.swift in Sources */,
 				0012562F2371D81500A9C067 /* SplashViewController.swift in Sources */,
 				00A057AF23D875840029C22A /* TariEventBus.swift in Sources */,
@@ -1713,6 +1731,7 @@
 				BFD758E723E98ABD00B0F1A5 /* ProfileViewController.swift in Sources */,
 				00BBD802237C5B5200EBF5E6 /* CommandLineArgs.swift in Sources */,
 				0091D4A823ED879E004BF7F7 /* Signature.swift in Sources */,
+				00DD1610241CD42500C955B4 /* BaseNode.swift in Sources */,
 				006D211E23CEDF16007D1C10 /* MicroTari.swift in Sources */,
 				0087A1B323F4235400B89EE7 /* AddRecipientViewController.swift in Sources */,
 				004277F823E0628A00AE7BD9 /* UIViewController.swift in Sources */,
@@ -1740,6 +1759,7 @@
 				00325ECB239E4A1000F76918 /* FadedOverlayView.swift in Sources */,
 				00A057B523D979DA0029C22A /* UserFeedback.swift in Sources */,
 				004997AC2382E893000A0B7D /* PendingOutboundTransactions.swift in Sources */,
+				00DD160D241CCE5B00C955B4 /* TariSettings.swift in Sources */,
 				00A994342396434B007D9990 /* QRButton.swift in Sources */,
 				00230B0A23770CEA00F23E34 /* CALayer.swift in Sources */,
 				0039B1B323FA925500F91E0F /* PasteEmojisView.swift in Sources */,
@@ -1820,6 +1840,7 @@
 				00BBD803237C5B5200EBF5E6 /* CommandLineArgs.swift in Sources */,
 				00325ECC239E4A1000F76918 /* FadedOverlayView.swift in Sources */,
 				00E2BCBC236B5BE800C2A105 /* ActionButton.swift in Sources */,
+				00DD1611241CD42500C955B4 /* BaseNode.swift in Sources */,
 				00A677A023743696001A853E /* TransactionViewController.swift in Sources */,
 				00230B0B23770CEA00F23E34 /* CALayer.swift in Sources */,
 				0087A1AE23F4235400B89EE7 /* ContactsTableViewController.swift in Sources */,
@@ -1829,6 +1850,7 @@
 				0091D4AD23ED87BE004BF7F7 /* TestnetKeyServer.swift in Sources */,
 				00C185C0238953F60096984E /* DebugLogsTableViewController.swift in Sources */,
 				004277E923DF4A5600AE7BD9 /* FeedbackView.swift in Sources */,
+				00DD160C241CCE5B00C955B4 /* TariSettings.swift in Sources */,
 				004277F523E0407900AE7BD9 /* TextButton.swift in Sources */,
 				001F6CE62380253B00FA7002 /* Contact.swift in Sources */,
 				009BF8AA237AA13500C02E44 /* Biometrics.m in Sources */,
@@ -2062,6 +2084,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LIBRARY = "libc++";
+				CODE_SIGN_ENTITLEMENTS = MobileWallet/Tari.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 41;
 				DEVELOPMENT_TEAM = 8974PBB98U;
@@ -2093,6 +2116,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LIBRARY = "libc++";
+				CODE_SIGN_ENTITLEMENTS = MobileWallet/Tari.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 41;
 				DEVELOPMENT_TEAM = 8974PBB98U;

--- a/MobileWallet/Common/NotificationManager.swift
+++ b/MobileWallet/Common/NotificationManager.swift
@@ -1,0 +1,94 @@
+//  NotificationManager.swift
+
+/*
+	Package MobileWallet
+	Created by Jason van den Berg on 2020/03/13
+	Using Swift 5.0
+	Running on macOS 10.15
+
+	Copyright 2019 The Tari Project
+
+	Redistribution and use in source and binary forms, with or
+	without modification, are permitted provided that the
+	following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above
+	copyright notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	3. Neither the name of the copyright holder nor the names of
+	its contributors may be used to endorse or promote products
+	derived from this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+	CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+	CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+	OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import UserNotifications
+
+class NotificationManager {
+    static let shared = NotificationManager()
+
+    let notificationCenter = UNUserNotificationCenter.current()
+    private let options: UNAuthorizationOptions = [.alert, .sound, .badge]
+
+    func requestAuthorization(_ completionHandler: @escaping (Bool) -> Void) {
+        notificationCenter.requestAuthorization(options: options) {
+            (didAllow, error) in
+            guard error == nil else {
+                print("PUSH ERROR")
+                print(error)
+                completionHandler(false)
+                return
+            }
+
+            completionHandler(didAllow)
+        }
+    }
+
+    func checkAuthorization(_ completionHandler: @escaping (Bool) -> Void) {
+        notificationCenter.getNotificationSettings { (settings) in
+            if settings.authorizationStatus == .authorized {
+                completionHandler(true)
+            } else {
+                completionHandler(false)
+            }
+        }
+    }
+
+    //TODO remove time interval, probably not needed
+    func scheduleNotification(title: String, body: String, timeInterval: TimeInterval = 1) {
+        let content = UNMutableNotificationContent()
+
+        content.title = title
+        content.body = body
+        content.sound = .default
+        content.badge = 1
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
+
+        let identifier = "Local Notification"
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+
+        notificationCenter.add(request) { (error) in
+            if let error = error {
+                print("Error \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/MobileWallet/Common/UserFeedback/FeedbackView.swift
+++ b/MobileWallet/Common/UserFeedback/FeedbackView.swift
@@ -95,7 +95,7 @@ class FeedbackView: UIView {
         descriptionLabel.textColor = Theme.shared.colors.feedbackPopupDescription
         descriptionLabel.font = Theme.shared.fonts.errorFeedbackPopupDescription
         descriptionLabel.textAlignment = .center
-        descriptionLabel.numberOfLines = 5
+        descriptionLabel.numberOfLines = 0
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
 
         descriptionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: SIDE_PADDING).isActive = true

--- a/MobileWallet/Common/UserFeedback/UserFeedback.swift
+++ b/MobileWallet/Common/UserFeedback/UserFeedback.swift
@@ -102,10 +102,11 @@ class UserFeedback {
         SwiftEntryKit.display(entry: successFeedbackView, using: attributes)
     }
 
-    func callToAction(title: String, description: String, cancelTitle: String, actionTitle: String, onAction: @escaping () -> Void) {
+    func callToAction(title: String, description: String, actionTitle: String, cancelTitle: String, onAction: @escaping () -> Void, onCancel: (() -> Void)? = nil) {
         let ctaFeedbackView = FeedbackView()
         ctaFeedbackView.setupCallToAction(title: title, description: description, cancelTitle: cancelTitle, actionTitle: actionTitle, onClose: {
             SwiftEntryKit.dismiss()
+            onCancel?()
         }, onAction: onAction)
 
         var attributes = defaultAttributes

--- a/MobileWallet/SceneDelegate.swift
+++ b/MobileWallet/SceneDelegate.swift
@@ -78,12 +78,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+
+        //Remove badges from push notifications
+        UIApplication.shared.applicationIconBadgeNumber = 0
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
+
+        BackgroundTaskManager.shared.scheduleAppRefresh()
 
         // Save changes in the application's managed object context when the application transitions to the background.
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()

--- a/MobileWallet/Screens/AppEntry/Splash/SplashViewController.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/SplashViewController.swift
@@ -91,7 +91,7 @@ class SplashViewController: UIViewController {
             titleAnimation()
             checkExistingWallet()
         }
-        
+
         handleWalletEvents()
     }
 

--- a/MobileWallet/Screens/Home/HomeViewController.swift
+++ b/MobileWallet/Screens/Home/HomeViewController.swift
@@ -133,6 +133,8 @@ class HomeViewController: UIViewController, FloatingPanelControllerDelegate, Tra
 
             self.refreshBalance()
         }
+
+        checkClipboardForBaseNode()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -154,8 +156,8 @@ class HomeViewController: UIViewController, FloatingPanelControllerDelegate, Tra
                     UserFeedback.shared.callToAction(
                         title: NSLocalizedString("You got some Tari!", comment: "Home view testnet airdrop"),
                         description: NSLocalizedString("TariBot has just sent you some Tari. To give the wallet a quick test, try sending TariBot back some Tari to see how it works.", comment: "Home view testnet airdrop"),
-                        cancelTitle: NSLocalizedString("I’ll try it later", comment: "Home view testnet airdrop"),
                         actionTitle: NSLocalizedString("Send Tari", comment: "Home view testnet airdrop"),
+                        cancelTitle: NSLocalizedString("I’ll try it later", comment: "Home view testnet airdrop"),
                         onAction: {
                             guard let self = self else { return }
                             self.onSend()

--- a/MobileWallet/Tari.entitlements
+++ b/MobileWallet/Tari.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/MobileWallet/TariLib/TariSettings.swift
+++ b/MobileWallet/TariLib/TariSettings.swift
@@ -1,0 +1,62 @@
+//  TariSettings.swift
+
+/*
+	Package MobileWallet
+	Created by Jason van den Berg on 2020/03/14
+	Using Swift 5.0
+	Running on macOS 10.15
+
+	Copyright 2019 The Tari Project
+
+	Redistribution and use in source and binary forms, with or
+	without modification, are permitted provided that the
+	following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above
+	copyright notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	3. Neither the name of the copyright holder nor the names of
+	its contributors may be used to endorse or promote products
+	derived from this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+	CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+	CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+	OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+enum TariNetworks: String {
+    case mainnet = "mainnet"
+    case rincewind = "rincewind"
+}
+
+struct TariSettings {
+    static let shared = TariSettings()
+
+    let network: TariNetworks = .rincewind //TODO this will come from a build config
+
+    //Taribot faucet node
+    let defaultBasenodePeer = "2e93c460df49d8cfbbf7a06dd9004c25a84f92584f7d0ac5e30bd8e0beee9a43::/onion3/nuuq3e2olck22rudimovhmrdwkmjncxvwdgbvfxhz6myzcnx2j4rssyd:18141"
+
+    //For UI changes it can be a bit slow to keep waiting for tor to bootstrap
+    #if targetEnvironment(simulator)
+    let TOR_ENABLED = false
+    #else
+    let TOR_ENABLED = true
+    #endif
+}

--- a/MobileWallet/TariLib/Wrappers/Utils/BaseNode.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/BaseNode.swift
@@ -1,0 +1,70 @@
+//  BaseNode.swift
+
+/*
+	Package MobileWallet
+	Created by Jason van den Berg on 2020/03/14
+	Using Swift 5.0
+	Running on macOS 10.15
+
+	Copyright 2019 The Tari Project
+
+	Redistribution and use in source and binary forms, with or
+	without modification, are permitted provided that the
+	following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above
+	copyright notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	3. Neither the name of the copyright holder nor the names of
+	its contributors may be used to endorse or promote products
+	derived from this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+	CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+	CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+	OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+enum BaseNodeErrors: Error {
+    case invalidPeerString
+    case addressNotOnion
+}
+
+struct BaseNode {
+    let publicKey: PublicKey
+    let address: String
+
+    //Expects format found in Tari code base for setting a peer: pubkey::/onion/key:port
+    //Can be used to determine if the users clipboard contains a valid base node seed
+    init(_ peer: String) throws {
+        let regex = try NSRegularExpression(pattern: "[a-z0-9]{64}::\\/onion3\\/[a-z0-9]{56}:[0-9]{2,6}")
+        guard regex.matches(in: peer, options: [], range: NSRange(location: 0, length: peer.utf16.count)).count == 1 else {
+            throw BaseNodeErrors.invalidPeerString
+        }
+
+        let splitPeerDetails = peer.components(separatedBy: "::")
+
+        //Sanity check. This would actually get caught by the regex above
+        guard splitPeerDetails.count == 2 else {
+            throw BaseNodeErrors.invalidPeerString
+        }
+
+        publicKey = try PublicKey(hex: splitPeerDetails[0])
+        address = splitPeerDetails[1]
+    }
+}

--- a/MobileWallet/TariLib/Wrappers/Wallet.swift
+++ b/MobileWallet/TariLib/Wrappers/Wallet.swift
@@ -411,11 +411,11 @@ class Wallet {
         }
     }
 
-    func addBaseNodePeer(publicKey: PublicKey, address: String) throws {
+    func addBaseNodePeer(_ basenode: BaseNode) throws {
         var errorCode: Int32 = -1
-        let addressPointer = (address as NSString).utf8String
+        let addressPointer = (basenode.address as NSString).utf8String
 
-        _ = wallet_add_base_node_peer(ptr, publicKey.pointer, addressPointer, UnsafeMutablePointer<Int32>(&errorCode))
+        _ = wallet_add_base_node_peer(ptr, basenode.publicKey.pointer, addressPointer, UnsafeMutablePointer<Int32>(&errorCode))
 
         guard errorCode == 0 else {
             throw WalletErrors.generic(errorCode)

--- a/MobileWalletTests/TariLibWrapperTests.swift
+++ b/MobileWalletTests/TariLibWrapperTests.swift
@@ -116,6 +116,16 @@ class TariLibWrapperTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+    
+    func testBaseNode() {
+        //Invalid peers
+        XCTAssertThrowsError(try BaseNode("bla bla bla"))
+        XCTAssertThrowsError(try BaseNode("5edb022af1c21d644dfceeea2fcc7d3fac7a57ab44cf775b9a6f692cb75ed767::/onion3/vjkj44zpriqzrlve2qbiasrluaaxagrb6iuavzaascbujri6gw3rcmyd"))
+        XCTAssertThrowsError(try BaseNode("5edb022af1c21d644dfceeea2fcc7d3fac7a57ab44cf775b9a6f692cb75ed767::vjkj44zpriqzrlve2qbiasrluaaxagrb6iuavzaascbujri6gw3rcmyd:18141"))
+
+        //Valid peer
+        XCTAssertNoThrow(try BaseNode("5edb022af1c21d644dfceeea2fcc7d3fac7a57ab44cf775b9a6f692cb75ed767::/onion3/vjkj44zpriqzrlve2qbiasrluaaxagrb6iuavzaascbujri6gw3rcmyd:18141"))
+    }
    
     func testWallet() {
         //MARK: Create new wallet


### PR DESCRIPTION
- Basenode struct with tests.
- Checking clipboard for base node peer details
- Clearing notification badges

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Using the background app refresh task to trigger local push notifications if a new tx is received.
- Added a base node struct that allows you to init with a peer string.
- Auto check clipboard for base node peer string, if it exists show a call to action that allows them to set this.

## Motivation and Context
<!--- What feature is it related to? Why is this change required? What problem does it solve?-->
<!--- If it fixes an open issue or closes a feature ticket, please link to the issue here. -->
Related to https://github.com/tari-project/wallet-ios/issues/101

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->
- Tests written for constructing a base node instance. 
- Tested local push notifications by triggering a test incoming tx.

## Screenshots and/or video clip
<!--- Only applicable if this PR has UI changes -->
<!--- Please upload screenshots from simulator of all device screen sizes -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added/changed tests to cover my changes if not UI changes.
