### PR TITLE
Improved discovery handling and log file cleanup

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -144,7 +144,6 @@
 		00369D812426080D00BAB95B /* TariLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00369D802426080D00BAB95B /* TariLogger.swift */; };
 		00369D84242618A900BAB95B /* TariLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00369D802426080D00BAB95B /* TariLogger.swift */; };
 		00369D852426195100BAB95B /* TariLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00369D802426080D00BAB95B /* TariLogger.swift */; };
-		00369D862426195300BAB95B /* TariLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00369D802426080D00BAB95B /* TariLogger.swift */; };
 		0039B1B223FA925500F91E0F /* PasteEmojisView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0039B1B123FA925500F91E0F /* PasteEmojisView.swift */; };
 		0039B1B323FA925500F91E0F /* PasteEmojisView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0039B1B123FA925500F91E0F /* PasteEmojisView.swift */; };
 		0039B1B423FA925500F91E0F /* PasteEmojisView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0039B1B123FA925500F91E0F /* PasteEmojisView.swift */; };
@@ -200,6 +199,7 @@
 		0074619B239A57B000F00966 /* UIBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0074619A239A57B000F00966 /* UIBarButtonItem.swift */; };
 		0074619C239A57B000F00966 /* UIBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0074619A239A57B000F00966 /* UIBarButtonItem.swift */; };
 		0074619D239A57B000F00966 /* UIBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0074619A239A57B000F00966 /* UIBarButtonItem.swift */; };
+		008758ED2427C9E800DC6BCB /* TariLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00369D802426080D00BAB95B /* TariLogger.swift */; };
 		0087A1A923F4235400B89EE7 /* ScanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0087A1A523F4235400B89EE7 /* ScanViewController.swift */; };
 		0087A1AA23F4235400B89EE7 /* ScanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0087A1A523F4235400B89EE7 /* ScanViewController.swift */; };
 		0087A1AB23F4235400B89EE7 /* ScanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0087A1A523F4235400B89EE7 /* ScanViewController.swift */; };
@@ -326,6 +326,9 @@
 		00E4922923683E54007B332D /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E4922823683E54007B332D /* HomeViewController.swift */; };
 		00E4922A23683E54007B332D /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E4922823683E54007B332D /* HomeViewController.swift */; };
 		00E4922B23683E54007B332D /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E4922823683E54007B332D /* HomeViewController.swift */; };
+		00F53A642428E44700448466 /* LogCleanup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F53A632428E44700448466 /* LogCleanup.swift */; };
+		00F53A6A24290F7100448466 /* LogCleanup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F53A632428E44700448466 /* LogCleanup.swift */; };
+		00F53A6B24290FAE00448466 /* LogCleanup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F53A632428E44700448466 /* LogCleanup.swift */; };
 		123181E402EDECC46E321212 /* Pods_MobileWallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F28D9135828811CA84244432 /* Pods_MobileWallet.framework */; };
 		1C2D151A197172FD352B6717 /* Pods_MobileWallet_MobileWalletUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 153952A60E3931ABC327A007 /* Pods_MobileWallet_MobileWalletUITests.framework */; };
 		491AB89A23F1B36000372189 /* AnimatedBalanceLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49996E1823F164BA002B6696 /* AnimatedBalanceLabel.swift */; };
@@ -590,6 +593,7 @@
 		00E491C02366E08F007B332D /* MobileWalletUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileWalletUITests.swift; sourceTree = "<group>"; };
 		00E491C22366E08F007B332D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E4922823683E54007B332D /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		00F53A632428E44700448466 /* LogCleanup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogCleanup.swift; sourceTree = "<group>"; };
 		0D5A214BA7374BF19AA25539 /* Pods-MobileWallet-MobileWalletTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MobileWallet-MobileWalletTests.debug.xcconfig"; path = "Target Support Files/Pods-MobileWallet-MobileWalletTests/Pods-MobileWallet-MobileWalletTests.debug.xcconfig"; sourceTree = "<group>"; };
 		149D41C0C9E88C8782E52C11 /* Pods-MobileWallet-MobileWalletTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MobileWallet-MobileWalletTests.release.xcconfig"; path = "Target Support Files/Pods-MobileWallet-MobileWalletTests/Pods-MobileWallet-MobileWalletTests.release.xcconfig"; sourceTree = "<group>"; };
 		153952A60E3931ABC327A007 /* Pods_MobileWallet_MobileWalletUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MobileWallet_MobileWalletUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -814,6 +818,8 @@
 		006D211B23CEDEEE007D1C10 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				00DD160A241CCE0600C955B4 /* TariSettings.swift */,
+				00369D802426080D00BAB95B /* TariLogger.swift */,
 				006D211C23CEDF16007D1C10 /* MicroTari.swift */,
 				00230AF92376C6DD00F23E34 /* Sequence.swift */,
 				00A057AE23D875840029C22A /* TariEventBus.swift */,
@@ -821,6 +827,7 @@
 				0091D4A623ED879E004BF7F7 /* Signature.swift */,
 				0091D4AA23ED87BE004BF7F7 /* TestnetKeyServer.swift */,
 				00DD160E241CD41D00C955B4 /* BaseNode.swift */,
+				00F53A632428E44700448466 /* LogCleanup.swift */,
 			);
 			name = Utils;
 			path = Wrappers/Utils;
@@ -1107,8 +1114,6 @@
 				4C2C95C223796184005058AB /* libzmq.a */,
 				4C2C95AF23795919005058AB /* libwallet_ffi.a */,
 				009BF8AB237ABB4700C02E44 /* TariLib.swift */,
-				00DD160A241CCE0600C955B4 /* TariSettings.swift */,
-				00369D802426080D00BAB95B /* TariLogger.swift */,
 				00BCE485240D5A9E00B181F3 /* Tor */,
 				006D211B23CEDEEE007D1C10 /* Utils */,
 				00BBD80C237DA04300EBF5E6 /* Wrappers */,
@@ -1748,7 +1753,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				00B4D6B82416A50C00ED8318 /* MobileWalletUISnapshots.swift in Sources */,
-				00369D862426195300BAB95B /* TariLogger.swift in Sources */,
+				008758ED2427C9E800DC6BCB /* TariLogger.swift in Sources */,
 				00B4D6BD24178DE300ED8318 /* HelperFunctions.swift in Sources */,
 				BFE61E4B24226A7F003DC99D /* NotificationManager.swift in Sources */,
 				00B4D6BC24178CBD00ED8318 /* Biometrics.m in Sources */,
@@ -1797,6 +1802,7 @@
 				00262EAF236F015000A6C8A0 /* UILabelWithPadding.swift in Sources */,
 				00369D812426080D00BAB95B /* TariLogger.swift in Sources */,
 				001F6CDC238011CA00FA7002 /* PublicKey.swift in Sources */,
+				00F53A642428E44700448466 /* LogCleanup.swift in Sources */,
 				004997B32382ED68000A0B7D /* PendingInboundTransaction.swift in Sources */,
 				0087A1B223F4235400B89EE7 /* AddRecipientViewController.swift in Sources */,
 				0091D4A723ED879E004BF7F7 /* Signature.swift in Sources */,
@@ -1868,6 +1874,7 @@
 				004277F823E0628A00AE7BD9 /* UIViewController.swift in Sources */,
 				00262EB5236F024400A6C8A0 /* Theme.swift in Sources */,
 				00E2BCB3236B455900C2A105 /* HomeViewFloatingPanelDelegates.swift in Sources */,
+				00F53A6B24290FAE00448466 /* LogCleanup.swift in Sources */,
 				00262EB0236F015000A6C8A0 /* UILabelWithPadding.swift in Sources */,
 				004277E823DF4A5600AE7BD9 /* FeedbackView.swift in Sources */,
 				0042780023E2F1D700AE7BD9 /* UIImage.swift in Sources */,
@@ -1996,6 +2003,7 @@
 				00A057B123D875840029C22A /* TariEventBus.swift in Sources */,
 				00BCE484240D5A9700B181F3 /* OnionConnector.swift in Sources */,
 				00262EBB236F35CD00A6C8A0 /* DummyTransaction.swift in Sources */,
+				00F53A6A24290F7100448466 /* LogCleanup.swift in Sources */,
 				0091D4A923ED879E004BF7F7 /* Signature.swift in Sources */,
 				00BBD807237D755600EBF5E6 /* HelperFunctions.swift in Sources */,
 				0042780523E8421200AE7BD9 /* String.swift in Sources */,

--- a/MobileWallet/AppDelegate.swift
+++ b/MobileWallet/AppDelegate.swift
@@ -50,6 +50,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         BackgroundTaskManager.shared.registerNodeSyncTask()
         ShortcutParser.shared.registerShortcuts()
 
+        if TariSettings.shared.isDebug {
+            TariLogger.info("Running app in debug mode")
+        }
+
         return true
     }
 

--- a/MobileWallet/Common/Theme.swift
+++ b/MobileWallet/Common/Theme.swift
@@ -223,9 +223,8 @@ struct Fonts: Loopable {
 
     // Sending tari screen
 
-    let sendingTariTitleLabelFirst = UIFont(name: "Avenir-Black", size: 18.0)
-    let sendingTariTitleLabelSecond = UIFont(name: "Avenir-Light", size: 18.0)
-    let sendingTariTitleLabelThird = UIFont(name: "Avenir-Book", size: 18.0)
+    let sendingTariTitleLabelFirst = UIFont(name: "Avenir-Light", size: 18.0)
+    let sendingTariTitleLabelSecond = UIFont(name: "Avenir-Black", size: 18.0)
 
     //Navigation bar
     let navigationBarTitle = UIFont(name: "AvenirLTStd-Heavy", size: 16.5) //Design spec size is 14.0

--- a/MobileWallet/Screens/Home/Transaction/TransactionViewController.swift
+++ b/MobileWallet/Screens/Home/Transaction/TransactionViewController.swift
@@ -313,21 +313,25 @@ class TransactionViewController: UIViewController, UITextFieldDelegate {
 
             //Hopefully we can add this back some time
             var statusEmoji = ""
-            switch tx.status.0 {
-            case .completed:
-                statusEmoji = " ✔️"
-            case .broadcast:
-                statusEmoji = " 📡"
-            case .mined:
-                statusEmoji = " ⛏️"
-            case .imported:
-                statusEmoji = " 🤖"
-            case .pending:
-                statusEmoji = " ⏳"
-            case .transactionNullError:
-                statusEmoji = " 🤔"
-            case .unknown:
-                statusEmoji = " 🤷"
+
+            //If the app is in debug mode, show the status
+            if TariSettings.shared.isDebug {
+                switch tx.status.0 {
+                case .completed:
+                    statusEmoji = " ✔️"
+                case .broadcast:
+                    statusEmoji = " 📡"
+                case .mined:
+                    statusEmoji = " ⛏️"
+                case .imported:
+                    statusEmoji = " 🤖"
+                case .pending:
+                    statusEmoji = " ⏳"
+                case .transactionNullError:
+                    statusEmoji = " 🤔"
+                case .unknown:
+                    statusEmoji = " 🤷"
+                }
             }
 
             transactionIDLabel.text = "\(txIdDisplay)\(statusEmoji)"

--- a/MobileWallet/Screens/Profile/ProfileViewController.swift
+++ b/MobileWallet/Screens/Profile/ProfileViewController.swift
@@ -343,13 +343,13 @@ class ProfileViewController: UIViewController {
             throw walletPublicKeyError!
         }
 
-        let (deeplink, deeplinkError) = pubKey.deeplink
-        guard deeplinkError == nil else {
-            throw deeplinkError!
+        let (emojis, emojisError) = pubKey.emojis
+        guard emojisError == nil else {
+            throw emojisError!
         }
 
         let pasteboard = UIPasteboard.general
-        pasteboard.string = deeplink
+        pasteboard.string = emojis
     }
 
     private func sendHapticNotification() {

--- a/MobileWallet/Screens/Send/AddNote/AddNoteViewController.swift
+++ b/MobileWallet/Screens/Send/AddNote/AddNoteViewController.swift
@@ -188,7 +188,7 @@ class AddNoteViewController: UIViewController, UITextViewDelegate, SlideViewDele
             onSendComplete(recipientAmount)
         } catch WalletErrors.generic(210) {
             //Discovery still needs to happen, this error is actually alright
-            onSendComplete(recipientAmount)
+            onSendComplete(recipientAmount, isDiscoveryComplete: false)
         } catch {
             UserFeedback.shared.error(
                 title: NSLocalizedString("Transaction failed", comment: "Add note view"),
@@ -199,9 +199,10 @@ class AddNoteViewController: UIViewController, UITextViewDelegate, SlideViewDele
         }
     }
 
-    func onSendComplete(_ amount: MicroTari) {
+    func onSendComplete(_ amount: MicroTari, isDiscoveryComplete: Bool = true) {
         let vc = SendingTariViewController()
         vc.tariAmount = amount
+        vc.isDiscoveryComplete = isDiscoveryComplete
         self.navigationController?.pushViewController(vc, animated: false)
     }
 }

--- a/MobileWallet/TariLib/TariLib.swift
+++ b/MobileWallet/TariLib/TariLib.swift
@@ -105,7 +105,7 @@ class TariLib {
 
     var isTorConnected: Bool {
         //If we're not using tor (for a simulator) or if tor is actually connected
-        return TariSettings.shared.TOR_ENABLED == false || OnionConnector.shared.currentTorConnectionState == .connected
+        return TariSettings.shared.torEnabled == false || OnionConnector.shared.currentTorConnectionState == .connected
     }
 
     init() {}
@@ -116,7 +116,7 @@ class TariLib {
     deinit {}
 
     private func transportType() throws -> TransportType {
-        if TariSettings.shared.TOR_ENABLED {
+        if TariSettings.shared.torEnabled {
             let torKey = ""
             let torBytes = [UInt8](torKey.utf8)
             let torIdentity = try ByteVector(byteArray: torBytes)
@@ -143,7 +143,7 @@ class TariLib {
             return
         }
 
-        guard TariSettings.shared.TOR_ENABLED else {
+        guard TariSettings.shared.torEnabled else {
             TariEventBus.postToMainThread(.torConnected, sender: URLSessionConfiguration.default)
             return
         }
@@ -220,5 +220,7 @@ class TariLib {
         } else {
             throw TariLibErrors.privateKeyNotFound
         }
+
+        logCleanup(maxMB: TariSettings.shared.maxMbLogsStorage)
     }
 }

--- a/MobileWallet/TariLib/Wrappers/Utils/LogCleanup.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/LogCleanup.swift
@@ -1,0 +1,104 @@
+//  LogCleanup.swift
+
+/*
+	Package MobileWallet
+	Created by Jason van den Berg on 2020/03/23
+	Using Swift 5.0
+	Running on macOS 10.15
+
+	Copyright 2019 The Tari Project
+
+	Redistribution and use in source and binary forms, with or
+	without modification, are permitted provided that the
+	following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above
+	copyright notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	3. Neither the name of the copyright holder nor the names of
+	its contributors may be used to endorse or promote products
+	derived from this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+	CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+	CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+	OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+private func totalBytes(files: [URL]) -> UInt64 {
+    var total: UInt64 = 0
+    files.forEach { (file) in
+        do {
+            let attr = try FileManager.default.attributesOfItem(atPath: file.path)
+            if let fileSize = attr[FileAttributeKey.size] as? UInt64 {
+                total = total + fileSize
+            }
+        } catch {
+            TariLogger.error("Failed to get log file size", error: error)
+        }
+    }
+
+    return total
+}
+
+private func getUnusedLogFiles() -> [URL] {
+    var allLogFiles: [URL] = []
+
+    //Exclude current log file being written to
+    TariLib.shared.allLogFiles.forEach { (file) in
+        print(file.lastPathComponent)
+        guard !TariLib.shared.logFilePath.contains(file.lastPathComponent) else {
+            return
+        }
+
+        allLogFiles.append(file)
+    }
+
+    return allLogFiles
+}
+
+func logCleanup(maxMB: UInt64) {
+    DispatchQueue.global().async {
+        let maxBytes = maxMB * 1000000
+
+        let fileManager = FileManager.default
+
+        var loopIterationsFailsafe = 0
+        while totalBytes(files: getUnusedLogFiles()) > maxBytes && loopIterationsFailsafe < 10 {
+            loopIterationsFailsafe = loopIterationsFailsafe + 1
+
+            guard let oldestFile = getUnusedLogFiles().last else {
+                TariLogger.error("Failed to get oldest log file")
+                break
+            }
+
+            guard fileManager.fileExists(atPath: oldestFile.path) else {
+                TariLogger.error("Oldest log file does not exist")
+                break
+            }
+
+            do {
+                try fileManager.removeItem(at: oldestFile)
+                TariLogger.info("Deleting log file: \(oldestFile.lastPathComponent)")
+            } catch {
+                TariLogger.error("Failed to delete log file", error: error)
+                break
+            }
+        }
+    }
+}

--- a/MobileWallet/TariLib/Wrappers/Utils/MicroTari.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/MicroTari.swift
@@ -57,6 +57,7 @@ struct MicroTari {
         formatter.negativePrefix = "-"
         return formatter
     }()
+
     private static let withOperatorFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
@@ -66,6 +67,7 @@ struct MicroTari {
         formatter.negativePrefix = "- "
         return formatter
     }()
+
     private static let preciseFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
@@ -74,6 +76,7 @@ struct MicroTari {
         formatter.negativePrefix = "- "
         return formatter
     }()
+
     private static let preciseWithOperatorFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
@@ -83,6 +86,7 @@ struct MicroTari {
         formatter.negativePrefix = "- "
         return formatter
     }()
+
     private static let editFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal

--- a/MobileWallet/TariLib/Wrappers/Utils/TariEventBus.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/TariEventBus.swift
@@ -48,6 +48,7 @@ public enum TariEventTypes: String {
     case transactionBroadcast = "tari-event-transaction-broadcase"
     case transactionMined = "tari-event-transaction-mined"
     case discoveryProcessComplete = "tari-event-discovery-process-complete"
+    case baseNodeSyncComplete = "tari-event-base-node-synce-complete"
 
     //Common UI updates
     case transactionListUpdate = "tari-event-transaction-list-update"

--- a/MobileWallet/TariLib/Wrappers/Utils/TariLogger.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/TariLogger.swift
@@ -6,6 +6,8 @@
 	Using Swift 5.0
 	Running on macOS 10.15
 
+    Used for logging from Swift code. Protocol logging happens in the Tari library.
+ 
 	Adapted from https://github.com/LN-Zap/zap-iOS/blob/master/Logger/Logger.swift
 */
 

--- a/MobileWallet/TariLib/Wrappers/Utils/TariSettings.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/TariSettings.swift
@@ -51,16 +51,21 @@ struct TariSettings {
     let network: TariNetworks = .rincewind //TODO this will come from a build config
     let deeplinkURI = "tari"
 
+    //For UI changes it can be a bit slow to keep waiting for tor to bootstrap.
+    //Set to false if you're just working on the UI.
+
+    #if DEBUG
+    //Used for showing a little extra detail in the UI to help debugging
+    let isDebug = true
+    let torEnabled = false
+    //Local macbook node
+    let defaultBasenodePeer = "10092c2299efcb5b8ec27ab847b5ec645d79536cf8cf40c7b8757fa141151864::/onion3/kgk5tclng6v2ohbufp3nhhes7f4camb5ukkxyudoph6hzj5ip65dv4yd:9050"
+    let maxMbLogsStorage: UInt64 = 5000 //5GB
+    #else
+    let isDebug = false
+    let torEnabled = true
     //Taribot faucet node
     let defaultBasenodePeer = "2e93c460df49d8cfbbf7a06dd9004c25a84f92584f7d0ac5e30bd8e0beee9a43::/onion3/nuuq3e2olck22rudimovhmrdwkmjncxvwdgbvfxhz6myzcnx2j4rssyd:18141"
-
-    //Local macbook node
-    //let defaultBasenodePeer = "10092c2299efcb5b8ec27ab847b5ec645d79536cf8cf40c7b8757fa141151864::/onion3/kgk5tclng6v2ohbufp3nhhes7f4camb5ukkxyudoph6hzj5ip65dv4yd:9050"
-
-    //For UI changes it can be a bit slow to keep waiting for tor to bootstrap
-    #if targetEnvironment(simulator)
-    let TOR_ENABLED = false
-    #else
-    let TOR_ENABLED = true
+    let maxMbLogsStorage: UInt64 = 500 //500MB
     #endif
 }

--- a/MobileWallet/TariLib/Wrappers/Wallet.swift
+++ b/MobileWallet/TariLib/Wrappers/Wallet.swift
@@ -217,10 +217,12 @@ class Wallet {
         }
 
         let discoveryProcessCompleteCallback: (@convention(c) (UInt64, Bool) -> Void)? = { txID, success in
+            TariEventBus.postToMainThread(.discoveryProcessComplete, sender: success) //TODO add the tx to the send and listener as well
             TariLogger.verbose("Discovery process complete lib callback. txID=\(txID) success=\(success)")
         }
 
         let baseNodeSyncCompleteCallback: (@convention(c) (UInt64, Bool) -> Void)? = { requestID, success in
+            TariEventBus.postToMainThread(.baseNodeSyncComplete)
             TariLogger.verbose("Base node sync lib callback. requestID=\(requestID) success=\(success)")
         }
 

--- a/update_dependencies.sh
+++ b/update_dependencies.sh
@@ -2,8 +2,7 @@
 
 echo "\n\n***Pulling latest Tari lib build***"
 curl -O https://www.tari.com/binaries/libtari_wallet_ffi-ios-0.3.1.tar.gz
-tar -xvf libtari_wallet_ffi-ios-*.tar.gz
-mv libtari_wallet_ffi.a MobileWallet/TariLib/
+tar -xvf libtari_wallet_ffi-ios-*.tar.gz && mv libtari_wallet_ffi.a MobileWallet/TariLib/
 
 echo "\n\n***Cleaning up***"
 rm libtari_wallet_ffi-ios-*.tar.gz


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Waiting on sending animation view until discovery is completed
- Reverted to copying just emojis to clipboard
- Log file cleanup to keep storage use reasonable

## Motivation and Context
<!--- What feature is it related to? Why is this change required? What problem does it solve?-->
<!--- If it fixes an open issue or closes a feature ticket, please link to the issue here. -->
- When sending a tx, the discovery process can take a while so it's better to keep the user on the animated sending view while waiting for a success/failure callback.
- Occasionally log files would get written to in a loop and consume far too much storage. Everytime the wallet is started a cleanup function is executed which keeps log file storage to a configurable maximum.
- Fixes https://github.com/tari-project/wallet-ios/issues/190

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

- Sending txs to known peers, unknown peers and non existent peers
- Running the app and watching older log files get deleted first when storage threshold is hit.

## Screenshots and/or video clip
<!--- Only applicable if this PR has UI changes -->
<!--- Please upload screenshots from simulator of all device screen sizes -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
