### PR TITLE
Start wallet once tor ports are opened, not once bootstrapped

### DIFF
--- a/MobileWallet/Screens/AppEntry/Splash/SplashViewController.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/SplashViewController.swift
@@ -97,6 +97,12 @@ class SplashViewController: UIViewController, UITextViewDelegate {
         }
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        SwiftEntryKit.dismiss()
+    }
+
     private func handleWalletEvents() {
         //Handle tor progress
         TariEventBus.onMainThread(self, eventType: .torConnectionProgress) { [weak self] (result) in
@@ -110,7 +116,10 @@ class SplashViewController: UIViewController, UITextViewDelegate {
                     attributes.shadow = .active(with: .init(color: EKColor(Theme.shared.colors.feedbackPopupBackground!), opacity: 0.35, radius: 10, offset: .zero))
                     attributes.displayDuration = .infinity
                     attributes.screenInteraction = .forward
-                    //SwiftEntryKit.display(entry: self.progressFeedbackView, using: attributes)
+
+                    if TariSettings.shared.isDebug {
+                        SwiftEntryKit.display(entry: self.progressFeedbackView, using: attributes)
+                    }
                 }
 
                 self.progressFeedbackView.setupSuccess(title: "Tor bootstrapping: \(progress)%")
@@ -122,8 +131,6 @@ class SplashViewController: UIViewController, UITextViewDelegate {
             guard let self = self else { return }
 
             self.progressFeedbackView.setupSuccess(title: "Tor connection established")
-
-            SwiftEntryKit.dismiss()
         }
 
         TariEventBus.onMainThread(self, eventType: .torConnectionFailed) { [weak self] (result) in
@@ -142,13 +149,13 @@ class SplashViewController: UIViewController, UITextViewDelegate {
     }
 
     private func onTorSuccess(_ onComplete: @escaping () -> Void) {
-        if TariLib.shared.isTorConnected {
+        if TariLib.shared.torPortsOpened {
             onComplete()
             return
         }
 
-        //Handle tor connected later
-        TariEventBus.onMainThread(self, eventType: .torConnected) { [weak self] (_) in
+        //Handle if tor ports opened later
+        TariEventBus.onMainThread(self, eventType: .torPortsOpened) { [weak self] (_) in
             guard let _ = self else { return }
             onComplete()
         }

--- a/MobileWallet/TariLib/Wrappers/Utils/LogCleanup.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/LogCleanup.swift
@@ -61,7 +61,6 @@ private func getUnusedLogFiles() -> [URL] {
 
     //Exclude current log file being written to
     TariLib.shared.allLogFiles.forEach { (file) in
-        print(file.lastPathComponent)
         guard !TariLib.shared.logFilePath.contains(file.lastPathComponent) else {
             return
         }

--- a/MobileWallet/TariLib/Wrappers/Utils/TariEventBus.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/TariEventBus.swift
@@ -55,6 +55,7 @@ public enum TariEventTypes: String {
     case balanceUpdate = "tari-event-balance-update"
 
     //Tor instantiation statuses
+    case torPortsOpened = "tari-event-tor-ports-opened"
     case torConnectionProgress = "tari-event-tor-connection-progress"
     case torConnected = "tari-event-tor-connected"
     case torConnectionFailed = "tari-event-tor-connection-failed"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Instead of waiting for the tor bootstrapping to complete, the app only needs to wait for the ports to be opened before starting the wallet.

## Motivation and Context
<!--- What feature is it related to? Why is this change required? What problem does it solve?-->
<!--- If it fixes an open issue or closes a feature ticket, please link to the issue here. -->
Speeds up the splash and create wallet views because it doesn't rely on the network being ready before opening the app.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
