### PR TITLE
Second UTXO import to store modal time gap & app display name.

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -485,7 +485,7 @@
 		00E2BCA8236AB28200C2A105 /* TransactionTableTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TransactionTableTableViewCell.xib; sourceTree = "<group>"; };
 		00E2BCB1236B455900C2A105 /* HomeViewFloatingPanelDelegates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewFloatingPanelDelegates.swift; sourceTree = "<group>"; };
 		00E2BCB9236B5BE800C2A105 /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
-		00E491962366E08B007B332D /* Tari.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tari.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		00E491962366E08B007B332D /* Tari Aurora.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Tari Aurora.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E491992366E08B007B332D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		00E4919B2366E08B007B332D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		00E491A22366E08B007B332D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -905,7 +905,7 @@
 		00E491972366E08B007B332D /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				00E491962366E08B007B332D /* Tari.app */,
+				00E491962366E08B007B332D /* Tari Aurora.app */,
 				00E491B12366E08F007B332D /* MobileWalletTests.xctest */,
 				00E491BC2366E08F007B332D /* MobileWalletUITests.xctest */,
 				00B4D6AB2416A32200ED8318 /* MobileWalletUISnapshots.xctest */,
@@ -1170,7 +1170,7 @@
 			);
 			name = MobileWallet;
 			productName = MobileWallet;
-			productReference = 00E491962366E08B007B332D /* Tari.app */;
+			productReference = 00E491962366E08B007B332D /* Tari Aurora.app */;
 			productType = "com.apple.product-type.application";
 		};
 		00E491B02366E08F007B332D /* MobileWalletTests */ = {
@@ -2057,7 +2057,7 @@
 				);
 				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tari.wallet;
-				PRODUCT_NAME = Tari;
+				PRODUCT_NAME = "Tari Aurora";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/MobileWallet/MobileWallet-bridging-header.h";
 				SWIFT_VERSION = 5.0;
@@ -2092,7 +2092,7 @@
 				);
 				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tari.wallet;
-				PRODUCT_NAME = Tari;
+				PRODUCT_NAME = "Tari Aurora";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/MobileWallet/MobileWallet-bridging-header.h";
 				SWIFT_VERSION = 5.0;
@@ -2130,7 +2130,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tari.app/Tari";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tari Aurora.app/Tari Aurora";
 			};
 			name = Debug;
 		};
@@ -2163,7 +2163,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "MobileWalletTests/MobileWalletTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tari.app/Tari";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tari Aurora.app/Tari Aurora";
 			};
 			name = Release;
 		};
@@ -2172,7 +2172,6 @@
 			baseConfigurationReference = 540C8A02EEFE26A1133C9AA7 /* Pods-MobileWallet-MobileWalletUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Tari.app/Tari";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8XGMD9X2H2;
@@ -2205,7 +2204,6 @@
 			baseConfigurationReference = F82E54DCA5096D029377C454 /* Pods-MobileWallet-MobileWalletUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Tari.app/Tari";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8XGMD9X2H2;

--- a/MobileWallet.xcodeproj/xcshareddata/xcschemes/MobileWallet.xcscheme
+++ b/MobileWallet.xcodeproj/xcshareddata/xcschemes/MobileWallet.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "00E491952366E08B007B332D"
-               BuildableName = "Tari.app"
+               BuildableName = "Tari Aurora.app"
                BlueprintName = "MobileWallet"
                ReferencedContainer = "container:MobileWallet.xcodeproj">
             </BuildableReference>
@@ -75,7 +75,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "00E491952366E08B007B332D"
-            BuildableName = "Tari.app"
+            BuildableName = "Tari Aurora.app"
             BlueprintName = "MobileWallet"
             ReferencedContainer = "container:MobileWallet.xcodeproj">
          </BuildableReference>
@@ -92,7 +92,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "00E491952366E08B007B332D"
-            BuildableName = "Tari.app"
+            BuildableName = "Tari Aurora.app"
             BlueprintName = "MobileWallet"
             ReferencedContainer = "container:MobileWallet.xcodeproj">
          </BuildableReference>

--- a/MobileWallet/Boards/Base.lproj/Main.storyboard
+++ b/MobileWallet/Boards/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="tmd-fb-j9y">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="tmd-fb-j9y">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -42,7 +42,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xCe-J5-eXY" userLabel="BalanceView">
                                 <rect key="frame" x="25" y="149" width="364" height="54"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lRr-wq-3sr" customClass="AnimatedBalanceLabel" customModule="Tari">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lRr-wq-3sr" customClass="AnimatedBalanceLabel" customModule="Tari_Aurora">
                                         <rect key="frame" x="24" y="3.5" width="320" height="47"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>

--- a/MobileWallet/Screens/Home/HomeViewController.swift
+++ b/MobileWallet/Screens/Home/HomeViewController.swift
@@ -221,12 +221,12 @@ class HomeViewController: UIViewController, FloatingPanelControllerDelegate, Tra
             return
         }
 
-        DispatchQueue.global().asyncAfter(deadline: .now() + 2) { [weak self] in
+        DispatchQueue.global().asyncAfter(deadline: .now() + 1.5) { [weak self] in
             guard let self = self else { return }
 
             do {
                 try keyServer.importSecondUtxo {
-                    DispatchQueue.main.async {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
                         UserFeedback.shared.callToActionStore()
                     }
                 }

--- a/MobileWallet/Screens/Send/SendingTari/SendingTariViewController.swift
+++ b/MobileWallet/Screens/Send/SendingTari/SendingTariViewController.swift
@@ -104,9 +104,14 @@ class SendingTariViewController: UIViewController {
             player = AVQueuePlayer()
             playerLayer = AVPlayerLayer(player: player)
             playerItem = AVPlayerItem(url: pathURL)
-            playerLooper = AVPlayerLooper(player: player,
-                                          templateItem: playerItem,
-                                          timeRange: CMTimeRange(start: CMTime.zero, end: CMTimeMake(value: duration, timescale: 1)))
+            playerLooper = AVPlayerLooper(
+                player: player,
+                templateItem: playerItem,
+                timeRange: CMTimeRange(
+                    start: CMTime.zero,
+                    end: CMTimeMake(value: duration, timescale: 1)
+                )
+            )
             playerLayer.videoGravity = AVLayerVideoGravity.resizeAspect
             playerLayer.frame = videoView.layer.bounds
             player.play()

--- a/MobileWallet/TariLib/Wrappers/Utils/TestnetKeyServer.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/TestnetKeyServer.swift
@@ -57,8 +57,21 @@ struct TestnetServerRequest: Codable {
 class TestnetKeyServer {
     private let MESSAGE_PREFIX = "Hello Tari from"
     private let SERVER = "https://faucet.tari.com" //TODO store in config
-    private let TARIBOT_MESSAGE1 = String(format: NSLocalizedString("💸 Here’s some %@!", comment: "TariBot transaction"), TariSettings.shared.network.currencyDisplayName)
-    private let TARIBOT_MESSAGE2 = String(format: NSLocalizedString("Nice work! Here's more Tari to fill your coffers. Be sure to hit the Store icon to see real, exclusive items you can redeem with your \"hard-earned\" testnet Tari.", comment: "TariBot transaction"), TariSettings.shared.network.currencyDisplayName)
+    private let TARIBOT_MESSAGE1 = String(
+        format: NSLocalizedString(
+            "💸 Here’s some %@!",
+            comment: "TariBot transaction"
+        ),
+        TariSettings.shared.network.currencyDisplayName
+    )
+    private let TARIBOT_MESSAGE2 = String(
+        format: NSLocalizedString(
+            "Nice work! Here's more Tari to fill your coffers. Be sure to hit the Store icon to see real, "
+            + "exclusive items you can redeem with your \"hard-earned\" testnet Tari.",
+            comment: "TariBot transaction"
+        ),
+        TariSettings.shared.network.currencyDisplayName
+    )
     private let signature: Signature
     private let url: URL
     private let wallet: Wallet
@@ -189,7 +202,12 @@ class TestnetKeyServer {
             }
 
             do {
-                let utxo = UTXO(privateKeyHex: key1, value: value1, message: self.TARIBOT_MESSAGE1, sourcePublicKeyHex: returnPubKeyHex)
+                let utxo = UTXO(
+                    privateKeyHex: key1,
+                    value: value1,
+                    message: self.TARIBOT_MESSAGE1,
+                    sourcePublicKeyHex: returnPubKeyHex
+                )
 
                 //Add TariBot as a contact
                 try self.wallet.addUpdateContact(alias: "TariBot", publicKeyHex: utxo.sourcePublicKeyHex)
@@ -211,7 +229,13 @@ class TestnetKeyServer {
             }
 
             do {
-                try self.storeUtxo(utxo: UTXO(privateKeyHex: key2, value: value2, message: self.TARIBOT_MESSAGE2, sourcePublicKeyHex: returnPubKeyHex))
+                try self.storeUtxo(
+                    utxo: UTXO(
+                        privateKeyHex: key2,
+                        value: value2,
+                        message: self.TARIBOT_MESSAGE2,
+                        sourcePublicKeyHex: returnPubKeyHex)
+                )
             } catch {
                 onRequestError(error)
                 return


### PR DESCRIPTION
## Description
Increases the gap between the second UTXO import and the store modal display (). Changes the app display name to Tari Aurora. Minor formatting.

## Motivation and Context
Solutions for tari-project/wallet-ios#235 and tari-project/wallet-ios#247.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots and/or video clip
<!--- Only applicable if this PR has UI changes -->
<!--- Please upload screenshots from simulator of all device screen sizes -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [ ] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [ ] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
