### PR TITLE
Only expire pending transactions after syncing with a base node

### DIFF
--- a/MobileWallet/TariLib/Wrappers/Utils/TariEventBus.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/TariEventBus.swift
@@ -111,6 +111,11 @@ open class TariEventBus {
         return TariEventBus.on(target, eventType: eventType, sender: sender, queue: OperationQueue.main, handler: handler)
     }
 
+    @discardableResult
+    open class func onBackgroundThread(_ target: AnyObject, eventType: TariEventTypes, sender: Any? = nil, handler: @escaping ((Notification?) -> Void)) -> NSObjectProtocol {
+        return TariEventBus.on(target, eventType: eventType, sender: sender, queue: OperationQueue(), handler: handler)
+    }
+
     // MARK: Unregister
 
     open class func unregister(_ target: AnyObject) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Transactions should only be expired after syncing successfully with a base node.

## Motivation and Context
<!--- What feature is it related to? Why is this change required? What problem does it solve?-->
<!--- If it fixes an open issue or closes a feature ticket, please link to the issue here. -->
Transactions were getting expired before confirming the wallet had the most up to date transactions states.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
