### PR TITLE
Only show refreshing animation when app is foregrounded

### DIFF
--- a/MobileWallet/Screens/Home/TransactionHistory/TransactionsTableViewController.swift
+++ b/MobileWallet/Screens/Home/TransactionHistory/TransactionsTableViewController.swift
@@ -142,13 +142,12 @@ class TransactionsTableViewController: UITableViewController {
             self.refreshTable()
         }
 
+        beginRefreshing()
         TariEventBus.onMainThread(self, eventType: .connectionMonitorStatusChanged) { [weak self] (_) in
             guard let self = self else { return }
 
             if ConnectionMonitor.shared.state.baseNodeSynced == true {
                 self.endRefreshingWithSuccess()
-            } else {
-                self.beginRefreshing()
             }
         }
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Start refreshing when the app is moved to foreground only. Ignoring base node sync fails that might happen later.

## Motivation and Context
Related to https://github.com/tari-project/wallet-ios/issues/314

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
