### PR TITLE
Tap to see Emoji button is not tappable

### DIFF
--- a/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
@@ -287,6 +287,7 @@ class WalletCreationViewController: UIViewController {
         tapToSeeFullEmojiButton.backgroundColor = Theme.shared.colors.tapToSeeFullEmojiBackground!
         tapToSeeFullEmojiButton.alpha = 0.0
         tapToSeeFullEmojiButton.setTitle(NSLocalizedString("Tap to see full Emoji ID", comment: "Tap to see full Emoji ID in wallet creation"), for: .normal)
+        tapToSeeFullEmojiButton.addTarget(self, action: #selector(tapToSeeButtonAction(_ :)), for: .touchUpInside)
         tapToSeeFullEmojiButton.setTitleColor(Theme.shared.colors.tapToSeeFullEmoji!, for: .normal)
         tapToSeeFullEmojiButton!.titleLabel?.font = Theme.shared.fonts.tapToSeeFullEmojiLabel!
 
@@ -748,12 +749,7 @@ class WalletCreationViewController: UIViewController {
                                               showContainerViewBlur: false)
 
             self.userEmojiContainer.tapToExpand = { [weak self] in
-                guard let self = self else { return }
-                if self.state == .showEmojiId {
-                    self.createEmojiButton.alpha = 1.0
-                    self.arrowImageView.alpha = 0.0
-                    self.tapToSeeFullEmojiButton.alpha = 0.0
-                }
+                self?.tapToExpandAction()
             }
         }
 
@@ -761,6 +757,19 @@ class WalletCreationViewController: UIViewController {
         secondLabelBottomConstant?.constant = 8
         secondLabelTop.layoutIfNeeded()
         secondLabelBottom.layoutIfNeeded()
+    }
+
+    @objc public func tapToSeeButtonAction(_ sender: UIButton) {
+        userEmojiContainer.expand(true)
+        tapToExpandAction()
+    }
+
+    private func tapToExpandAction() {
+        if self.state == .showEmojiId {
+            self.createEmojiButton.alpha = 1.0
+            self.arrowImageView.alpha = 0.0
+            self.tapToSeeFullEmojiButton.alpha = 0.0
+        }
     }
 
     private func updateLabelsForLocalAuthentification() {

--- a/MobileWallet/UIElements/EmoticonView.swift
+++ b/MobileWallet/UIElements/EmoticonView.swift
@@ -216,11 +216,14 @@ class EmoticonView: UIView {
     }
 
     @objc func tap(_ gestureRecognizer: UITapGestureRecognizer) {
-        if !expanded {
-            expanded = true
-            enableFullScreen()
+        expand(!expanded, callCompletion: true)
+    }
+
+    func expand(_ expand: Bool, callCompletion: Bool = false) {
+        expanded = expand
+        if expand == true {
+            enableFullScreen(callCompletion: callCompletion)
         } else {
-            expanded = false
             disableFullScreen()
         }
     }
@@ -249,7 +252,7 @@ class EmoticonView: UIView {
         }
     }
 
-    private func enableFullScreen() {
+    private func enableFullScreen(callCompletion: Bool) {
 
         UIView.animate(withDuration: 0.3, animations: { [weak self] in
             guard let self = self else { return }
@@ -257,18 +260,15 @@ class EmoticonView: UIView {
         }) { [weak self] (_) in
             guard let self = self else { return }
             self.determineEmojiLabelText(emojiText: self.emojiText)
-            self.runFullScreenAnimation()
+            self.runFullScreenAnimation(callCompletion: callCompletion)
             UIView.animate(withDuration: 0.3, animations: { [weak self] in
                 guard let self = self else { return }
                 self.label.alpha = 1.0
-            }) { [weak self] (_) in
-                guard let self = self else { return }
-
-            }
+            })
         }
     }
 
-    private func runFullScreenAnimation() {
+    private func runFullScreenAnimation(callCompletion: Bool) {
         if backgroundLeft == nil && backgroundRight == nil && backgroundBottom == nil && backgroundTop == nil {
                 if let superview = self.superview {
                     backgroundLeft = containerView.leadingAnchor.constraint(equalTo: superview.leadingAnchor)
@@ -304,7 +304,9 @@ class EmoticonView: UIView {
                 })
             }
 
+        if callCompletion == true {
             tapToExpand?()
+        }
 
             scrollView.contentOffset = CGPoint(x: 30, y: 0)
 


### PR DESCRIPTION
## Description
now tooltip is tappable and displays the user's full Emoji ID when tapped by a user

## Motivation and Context
tari-project/wallet-ios#313

## How Has This Been Tested?
run tests, manual testing

## Video
![Запись-экрана-2020-04-24-в-16 26 36](https://user-images.githubusercontent.com/60744748/80217620-adcecd00-8648-11ea-8c44-3ab3fb97eb96.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
