### PR TITLE
Shadow under FaceID, TouchID, Notifications animations

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -264,6 +264,10 @@
 		37AFE265245193CA006EA270 /* AlwaysPoppableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFE264245193CA006EA270 /* AlwaysPoppableNavigationController.swift */; };
 		37AFE266245193CA006EA270 /* AlwaysPoppableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFE264245193CA006EA270 /* AlwaysPoppableNavigationController.swift */; };
 		37AFE267245193CA006EA270 /* AlwaysPoppableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFE264245193CA006EA270 /* AlwaysPoppableNavigationController.swift */; };
+		37BB696B245705D20013AC4D /* RadialGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BB696A245705D20013AC4D /* RadialGradientView.swift */; };
+		37BB696C245705E60013AC4D /* RadialGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BB696A245705D20013AC4D /* RadialGradientView.swift */; };
+		37BB696D245705E70013AC4D /* RadialGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BB696A245705D20013AC4D /* RadialGradientView.swift */; };
+		37BB696E245705E70013AC4D /* RadialGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BB696A245705D20013AC4D /* RadialGradientView.swift */; };
 		37CB9F8A2451A2AD00C495F2 /* String+Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CB9F892451A2AD00C495F2 /* String+Emoji.swift */; };
 		37CB9F8B2451A2AD00C495F2 /* String+Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CB9F892451A2AD00C495F2 /* String+Emoji.swift */; };
 		37CB9F8C2451A2AD00C495F2 /* String+Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CB9F892451A2AD00C495F2 /* String+Emoji.swift */; };
@@ -519,6 +523,7 @@
 		2FF33C780E811D173D3284C3 /* Pods-MobileWalletUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MobileWalletUITests.debug.xcconfig"; path = "Target Support Files/Pods-MobileWalletUITests/Pods-MobileWalletUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		379D27AE244EF25000F1AD98 /* NavigationBarWithSubtitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarWithSubtitle.swift; sourceTree = "<group>"; };
 		37AFE264245193CA006EA270 /* AlwaysPoppableNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlwaysPoppableNavigationController.swift; sourceTree = "<group>"; };
+		37BB696A245705D20013AC4D /* RadialGradientView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RadialGradientView.swift; sourceTree = "<group>"; };
 		37CB9F892451A2AD00C495F2 /* String+Emoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Emoji.swift"; sourceTree = "<group>"; };
 		37E4B62A24501FB200FA302B /* HomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		491AB89F23F3FF4400372189 /* AddAmountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAmountViewController.swift; sourceTree = "<group>"; };
@@ -855,6 +860,7 @@
 		00E2BCAF236B44CE00C2A105 /* UIElements */ = {
 			isa = PBXGroup;
 			children = (
+				37BB6969245705D20013AC4D /* RadialGradientView */,
 				00E2BCB8236B5BC000C2A105 /* Buttons */,
 				00E2BCB0236B44DB00C2A105 /* FloatingPanel */,
 				00325EC9239E4A1000F76918 /* FadedOverlayView.swift */,
@@ -1001,6 +1007,14 @@
 				37AFE264245193CA006EA270 /* AlwaysPoppableNavigationController.swift */,
 			);
 			path = AlwaysPoppableNavigationController;
+			sourceTree = "<group>";
+		};
+		37BB6969245705D20013AC4D /* RadialGradientView */ = {
+			isa = PBXGroup;
+			children = (
+				37BB696A245705D20013AC4D /* RadialGradientView.swift */,
+			);
+			path = RadialGradientView;
 			sourceTree = "<group>";
 		};
 		491AB89E23F3FF1200372189 /* AddAmount */ = {
@@ -1573,6 +1587,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				00B4D6B82416A50C00ED8318 /* MobileWalletUISnapshots.swift in Sources */,
+				37BB696E245705E70013AC4D /* RadialGradientView.swift in Sources */,
 				00B4D6BD24178DE300ED8318 /* HelperFunctions.swift in Sources */,
 				BFCA0E6C242CA8780024FC0C /* TariLogger.swift in Sources */,
 				00B4D6BC24178CBD00ED8318 /* Biometrics.m in Sources */,
@@ -1669,6 +1684,7 @@
 				379D27AF244EF25000F1AD98 /* NavigationBarWithSubtitle.swift in Sources */,
 				BFAB5D1123FDEA69009E8563 /* EmoticonView.swift in Sources */,
 				37AFE265245193CA006EA270 /* AlwaysPoppableNavigationController.swift in Sources */,
+				37BB696B245705D20013AC4D /* RadialGradientView.swift in Sources */,
 				004277FB23E1A61F00AE7BD9 /* ErrorDescriptions.swift in Sources */,
 				0042780323E8421200AE7BD9 /* String.swift in Sources */,
 				0087A1AC23F4235400B89EE7 /* ContactsTableViewController.swift in Sources */,
@@ -1720,6 +1736,7 @@
 				00C185BF238953F60096984E /* DebugLogsTableViewController.swift in Sources */,
 				00A6779F23743696001A853E /* TransactionViewController.swift in Sources */,
 				00369D7E2422670300BAB95B /* DeepLinkManager.swift in Sources */,
+				37BB696C245705E60013AC4D /* RadialGradientView.swift in Sources */,
 				BFE1FC0923E3ACD900BA5EEC /* WalletCreationViewController.swift in Sources */,
 				00947CC323CF090D00526DD5 /* TransactionProtocol.swift in Sources */,
 				00A66528243C766D0046E730 /* ConnectionMonitor.swift in Sources */,
@@ -1862,6 +1879,7 @@
 				004277DF23DC2EAB00AE7BD9 /* EmojiButton.swift in Sources */,
 				004997B52382ED68000A0B7D /* PendingInboundTransaction.swift in Sources */,
 				00230B042376C75B00F23E34 /* TransactionsTableViewControllerExtension.swift in Sources */,
+				37BB696D245705E70013AC4D /* RadialGradientView.swift in Sources */,
 				00A66529243C766D0046E730 /* ConnectionMonitor.swift in Sources */,
 				619198F3E20DFABEB23F63FE /* UTXO.swift in Sources */,
 			);

--- a/MobileWallet/Assets.xcassets/Colors/AccessAnimationViewShadow.colorset/Contents.json
+++ b/MobileWallet/Assets.xcassets/Colors/AccessAnimationViewShadow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.400",
+          "blue" : "213",
+          "green" : "119",
+          "red" : "133"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MobileWallet/Common/Theme.swift
+++ b/MobileWallet/Common/Theme.swift
@@ -70,6 +70,8 @@ struct Colors: Loopable {
     let gradient1 = UIColor(named: "Gradient1")
     let gradient2 = UIColor(named: "Gradient2")
 
+    let accessAnimationViewShadow = UIColor(named: "AccessAnimationViewShadow")
+
     let actionButtonBackgroundSimple = UIColor(named: "ActionButtonBackgroundSimple")
     let actionButtonTitle = UIColor(named: "ActionButtonTitle")
 

--- a/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
@@ -66,24 +66,30 @@ class WalletCreationViewController: UIViewController {
     var secondLabelBottomConstant: NSLayoutConstraint?
     var thirdLabelLeadingConstant: NSLayoutConstraint?
     var thirdLabelTrailingConstant: NSLayoutConstraint?
-    var faceIdWidthConstaint: NSLayoutConstraint?
-    var faceIdHeightConstaint: NSLayoutConstraint?
-    var faceIdDistanceToLabel: NSLayoutConstraint?
+    var accessAnimationViewWidthConstaint: NSLayoutConstraint?
+    var accessAnimationViewHeightConstaint: NSLayoutConstraint?
+    var accessAnimationViewDistanceToLabel: NSLayoutConstraint?
+    var accessAnimationViewDistanceToXCenter: NSLayoutConstraint?
+    var radialGradientViewDistanceToXCenter: NSLayoutConstraint?
+    var radialGradientViewDistanceToYCenter: NSLayoutConstraint?
+
     var firstLabel: UILabel!
     var secondLabelTop: UILabel!
     var secondLabelBottom: UILabel!
     var thirdLabel: UILabel!
     var topWhiteView: UIView!
     var bottomWhiteView: UIView!
-    var animationView: AnimationView!
     var emojiWheelView: AnimationView!
     var nerdAnimationView: AnimationView!
+    var checkmarkAnimationView: AnimationView!
     var videoView: UIView!
     var createEmojiButton: ActionButton!
     var userEmojiContainer: EmoticonView!
     var tapToSeeFullEmojiButton: UIButton!
     var arrowImageView: UIImageView!
-    var faceIDView: AnimationView!
+    var accessAnimationView: AnimationView!
+
+    let radialGradient: RadialGradientView = RadialGradientView(insideColor: Theme.shared.colors.accessAnimationViewShadow!, outsideColor: Theme.shared.colors.creatingWalletBackground!)
 
     // MARK: - Override functions
     override func viewDidLoad() {
@@ -167,13 +173,13 @@ class WalletCreationViewController: UIViewController {
     }
 
     private func updateConstraintsAnimationView() {
-        animationView = AnimationView()
-        view.addSubview(animationView)
-        animationView.translatesAutoresizingMaskIntoConstraints = false
-        animationView.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: 0).isActive = true
-        animationView.widthAnchor.constraint(equalToConstant: 43.75).isActive = true
-        animationView.heightAnchor.constraint(equalToConstant: 30).isActive = true
-        animationView.topAnchor.constraint(equalTo: bottomWhiteView.topAnchor, constant: -50).isActive = true
+        checkmarkAnimationView = AnimationView()
+        view.addSubview(checkmarkAnimationView)
+        checkmarkAnimationView.translatesAutoresizingMaskIntoConstraints = false
+        checkmarkAnimationView.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: 0).isActive = true
+        checkmarkAnimationView.widthAnchor.constraint(equalToConstant: 43.75).isActive = true
+        checkmarkAnimationView.heightAnchor.constraint(equalToConstant: 30).isActive = true
+        checkmarkAnimationView.topAnchor.constraint(equalTo: bottomWhiteView.topAnchor, constant: -50).isActive = true
     }
 
     private func updateConstraintsBottomWhiteView() {
@@ -254,17 +260,34 @@ class WalletCreationViewController: UIViewController {
 
     }
 
-    private func updateConstraintsFaceIDView() {
-        faceIDView = AnimationView()
-        view.addSubview(faceIDView)
-        faceIDView.translatesAutoresizingMaskIntoConstraints = false
-        faceIDView.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: 0).isActive = true
-        faceIdWidthConstaint = faceIDView.widthAnchor.constraint(equalToConstant: 238)
-        faceIdWidthConstaint?.isActive = true
-        faceIdHeightConstaint = faceIDView.heightAnchor.constraint(equalToConstant: 238)
-        faceIdHeightConstaint?.isActive = true
-        faceIdDistanceToLabel = secondLabelBottom.topAnchor.constraint(equalTo: faceIDView.bottomAnchor, constant: -30)
-        faceIdDistanceToLabel?.isActive = true
+    private func updateConstraintsAccessAnimationView() {
+        accessAnimationView = AnimationView()
+
+        radialGradient.gradienLayer.transform = CATransform3DMakeScale(0.75, 0.9, 0.7)
+        radialGradient.gradienLayer.locations = [0.0, 0.7]
+        radialGradient.gradienLayer.opacity = 0.2
+        radialGradient.alpha = 0.0
+
+        view.addSubview(accessAnimationView)
+        accessAnimationView.insertSubview(radialGradient, at: 0)
+
+        accessAnimationView.translatesAutoresizingMaskIntoConstraints = false
+        accessAnimationViewDistanceToXCenter = accessAnimationView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        accessAnimationViewDistanceToXCenter?.isActive = true
+        accessAnimationViewWidthConstaint = accessAnimationView.widthAnchor.constraint(equalToConstant: 238)
+        accessAnimationViewWidthConstaint?.isActive = true
+        accessAnimationViewHeightConstaint = accessAnimationView.heightAnchor.constraint(equalToConstant: 238)
+        accessAnimationViewHeightConstaint?.isActive = true
+        accessAnimationViewDistanceToLabel = secondLabelBottom.topAnchor.constraint(equalTo: accessAnimationView.bottomAnchor, constant: -30)
+        accessAnimationViewDistanceToLabel?.isActive = true
+
+        radialGradient.translatesAutoresizingMaskIntoConstraints = false
+        radialGradient.widthAnchor.constraint(equalTo: accessAnimationView.widthAnchor, multiplier: 1.0).isActive = true
+        radialGradient.heightAnchor.constraint(equalTo: accessAnimationView.heightAnchor, multiplier: 1.0).isActive = true
+        radialGradientViewDistanceToYCenter = radialGradient.centerYAnchor.constraint(equalTo: accessAnimationView.centerYAnchor)
+        radialGradientViewDistanceToYCenter?.isActive = true
+        radialGradientViewDistanceToXCenter = radialGradient.centerXAnchor.constraint(equalTo: accessAnimationView.centerXAnchor)
+        radialGradientViewDistanceToYCenter?.isActive = true
     }
 
     private func updateConstraintsUserEmojiContainer() {
@@ -343,7 +366,7 @@ class WalletCreationViewController: UIViewController {
         updateConstraintsThirdLabel()
         updateConstraintsEmojiButton()
         updateConstraintsEmojiWheelView()
-        updateConstraintsFaceIDView()
+        updateConstraintsAccessAnimationView()
         updateConstraintsUserEmojiContainer()
         updateConstraintsTapToSeeFullEmoji()
         updateConstraintsVideoView()
@@ -453,11 +476,11 @@ class WalletCreationViewController: UIViewController {
 
     private func loadCheckMarkAnimation() {
         let animation = Animation.named("CheckMark")
-        animationView.animation = animation
+        checkmarkAnimationView.animation = animation
     }
 
     private func startCheckMarkAnimation() {
-        animationView.play(
+        checkmarkAnimationView.play(
             fromProgress: 0,
             toProgress: 1,
             loopMode: .playOnce,
@@ -475,11 +498,11 @@ class WalletCreationViewController: UIViewController {
 
     private func loadFaceIDAnimation() {
         let animation = Animation.named("FaceID")
-        faceIDView.animation = animation
+        accessAnimationView.animation = animation
     }
 
     private func startFaceIDAnimation() {
-        faceIDView.play(
+        accessAnimationView.play(
             fromProgress: 0,
             toProgress: 1,
             loopMode: .playOnce,
@@ -493,11 +516,11 @@ class WalletCreationViewController: UIViewController {
 
     private func loadTouchIdAnimation() {
         let animation = Animation.named("TouchIdAnimation")
-        faceIDView.animation = animation
+        accessAnimationView.animation = animation
     }
 
     private func startTouchIdAnimation() {
-        faceIDView.play(
+        accessAnimationView.play(
             fromProgress: 0,
             toProgress: 1,
             loopMode: .playOnce,
@@ -511,11 +534,11 @@ class WalletCreationViewController: UIViewController {
 
     private func loadNotificationAnimation() {
         let animation = Animation.named("NotificationAnimation")
-        faceIDView.animation = animation
+        accessAnimationView.animation = animation
     }
 
     private func startNotificationAnimation() {
-        faceIDView.play(
+        accessAnimationView.play(
             fromProgress: 0,
             toProgress: 1,
             loopMode: .playOnce,
@@ -627,6 +650,7 @@ class WalletCreationViewController: UIViewController {
         let currentType = LAContext().biometricType
         switch currentType {
             case .faceID:
+                updateConstraintsForFaceIDAnimation()
                 runFaceIDAnimation()
             case .touchID:
                 runTouchIdAnimation()
@@ -635,27 +659,27 @@ class WalletCreationViewController: UIViewController {
                 TariLogger.error("No biometrics available")
         }
 
+        UIView.animate(withDuration: 1.0) { [weak self] in
+            self?.radialGradient.alpha = 1.0
+        }
+
         secondLabelTopConstant?.constant = -50
         UIView.animate(withDuration: 0.5, animations: { [weak self] in
-            guard let self = self else { return }
-            self.view.layoutIfNeeded()
+            self?.view.layoutIfNeeded()
         })
 
         secondLabelBottomConstant?.constant = -25
         UIView.animate(withDuration: 0.75, animations: { [weak self] in
-            guard let self = self else { return }
-            self.view.layoutIfNeeded()
+            self?.view.layoutIfNeeded()
         })
 
         UIView.animate(withDuration: 1, animations: { [weak self] in
-            guard let self = self else { return }
-            self.secondLabelBottom.alpha = 1.0
-            self.thirdLabel.alpha = 1.0
-            self.createEmojiButton.alpha = 1.0
-            self.view.layoutIfNeeded()
+            self?.secondLabelBottom.alpha = 1.0
+            self?.thirdLabel.alpha = 1.0
+            self?.createEmojiButton.alpha = 1.0
+            self?.view.layoutIfNeeded()
         }) { [weak self] (_) in
-            guard let self = self else { return }
-            self.state = .localAuthentication
+            self?.state = .localAuthentication
         }
     }
 
@@ -666,7 +690,7 @@ class WalletCreationViewController: UIViewController {
             self.secondLabelTop.alpha = 0.0
             self.secondLabelBottom.alpha = 0.0
             self.thirdLabel.alpha = 0.0
-            self.faceIDView.alpha = 0.0
+            self.accessAnimationView.alpha = 0.0
             self.view.layoutIfNeeded()
         }) { [weak self] (_) in
             guard let self = self else { return }
@@ -674,7 +698,7 @@ class WalletCreationViewController: UIViewController {
             DispatchQueue.main.asyncAfter(deadline: .now()) { [weak self] in
                 guard let self = self else { return }
                 self.updateLabelsForEnablingNotifications()
-                self.faceIDView.stop()
+                self.accessAnimationView.stop()
                 self.showEnableNotifications()
             }
         }
@@ -701,7 +725,7 @@ class WalletCreationViewController: UIViewController {
             self.secondLabelBottom.alpha = 1.0
             self.thirdLabel.alpha = 1.0
             self.createEmojiButton.alpha = 1.0
-            self.faceIDView.alpha = 1.0
+            self.accessAnimationView.alpha = 1.0
             self.view.layoutIfNeeded()
         }) { [weak self] (_) in
             guard let self = self else { return }
@@ -723,12 +747,27 @@ class WalletCreationViewController: UIViewController {
 
         secondLabelTopConstant?.constant = 8
         secondLabelBottomConstant?.constant = 8
-        faceIdWidthConstaint?.constant = 330
-        faceIdHeightConstaint?.constant = 362
-        faceIdDistanceToLabel?.constant = -90
-        faceIDView.layoutIfNeeded()
+        accessAnimationViewWidthConstaint?.constant = 330
+        accessAnimationViewHeightConstaint?.constant = 362
+        accessAnimationViewDistanceToLabel?.constant = -90
+
+        let translation = CATransform3DMakeTranslation(0.0, -70, 0)
+        let scale = CATransform3DMakeScale(0.6, 0.8, 0.7)
+        let combinedTransform = CATransform3DConcat(translation, scale)
+        radialGradient.gradienLayer.transform = combinedTransform
+
+        accessAnimationView.layoutIfNeeded()
         secondLabelTop.layoutIfNeeded()
         secondLabelBottom.layoutIfNeeded()
+    }
+
+    private func updateConstraintsForFaceIDAnimation() {
+        accessAnimationViewDistanceToXCenter?.constant = -7
+        radialGradientViewDistanceToXCenter?.constant = 7
+        radialGradientViewDistanceToYCenter?.constant = -10
+
+        let scale = CATransform3DMakeScale(1.0, 1.0, 1.0)
+        radialGradient.gradienLayer.transform = scale
     }
 
     private func updateLabelsForShowEmojiId() {

--- a/MobileWallet/UIElements/RadialGradientView/RadialGradientView.swift
+++ b/MobileWallet/UIElements/RadialGradientView/RadialGradientView.swift
@@ -1,0 +1,74 @@
+//  RadialGradientView.swift
+
+/*
+	Package MobileWallet
+	Created by S.Shovkoplyas on 27.04.2020
+	Using Swift 5.0
+	Running on macOS 10.15
+
+	Copyright 2019 The Tari Project
+
+	Redistribution and use in source and binary forms, with or
+	without modification, are permitted provided that the
+	following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above
+	copyright notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	3. Neither the name of the copyright holder nor the names of
+	its contributors may be used to endorse or promote products
+	derived from this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+	CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+	CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+	OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import UIKit
+
+class RadialGradientView: UIView {
+
+    var insideColor: UIColor
+    var outsideColor: UIColor
+
+    init(insideColor: UIColor, outsideColor: UIColor) {
+        self.insideColor = insideColor
+        self.outsideColor = outsideColor
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    lazy var gradienLayer: CAGradientLayer = {
+        let l = CAGradientLayer()
+        l.type = .radial
+        l.colors = [insideColor.cgColor,
+                    outsideColor.cgColor]
+        l.startPoint = CGPoint(x: 0.5, y: 0.5)
+        l.endPoint = CGPoint(x: 1, y: 1)
+        layer.addSublayer(l)
+        return l
+    }()
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradienLayer.frame = bounds
+        gradienLayer.cornerRadius = bounds.width / 2.0
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
added shadow (radial gradient layer below lottieView)
also faceId animation view is moved some left

## Motivation and Context
tari-project/wallet-ios#323

## How Has This Been Tested?
run tests, manual simulator testing

## Screenshots and/or video clip
## iPhone 8
![Simulator Screen Shot - iPhone 8 - 2020-04-27 at 15 18 05](https://user-images.githubusercontent.com/60744748/80372295-05b14200-889c-11ea-9d72-b483f7453199.png)

## iPhone 8 Plus
![Simulator Screen Shot - iPhone 8 Plus - 2020-04-27 at 15 19 40](https://user-images.githubusercontent.com/60744748/80372310-08ac3280-889c-11ea-8287-822991657d6b.png)

## iPhone Xs
![Simulator Screen Shot - iPhone Xs 13 4 - 2020-04-27 at 15 16 43](https://user-images.githubusercontent.com/60744748/80372326-0fd34080-889c-11ea-871a-0183f437a1df.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
