### PR TITLE
Number keyboard crash

### DIFF
--- a/MobileWallet/Screens/Send/AddAmount/AddAmountViewController.swift
+++ b/MobileWallet/Screens/Send/AddAmount/AddAmountViewController.swift
@@ -198,8 +198,10 @@ class AddAmountViewController: UIViewController {
             return
         }
 
-        rawInput = updatedText
-        updateLabelText()
+        if MicroTari.checkValue(updatedText) {
+            rawInput = updatedText
+            updateLabelText()
+        }
     }
 
     private func updateLabelText() {

--- a/MobileWallet/TariLib/Wrappers/Utils/MicroTari.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/MicroTari.swift
@@ -156,4 +156,16 @@ extension MicroTari {
         editFormatter.minimumFractionDigits = minimumFractionDigits
         return editFormatter.string(from: number)
     }
+
+    public static func checkValue(_ value: NSNumber) -> Bool {
+        guard let _ = UInt64(exactly: value.floatValue * Float(MicroTari.CONVERSION)) else {
+            return false
+        }
+        return true
+    }
+
+    public static func checkValue(_ value: String) -> Bool {
+        guard let number = convertToNumber(value) else { return false }
+        return checkValue(number)
+    }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
fixed crash when you tap number buttons too quickly.

Main problem is not fast tapping. Main problem that our value has UInt64 type. App crashes if we try to enter value greater than UIn64 can afford.
Added check for value before convert to UInt64

## Motivation and Context
tari-project/wallet-ios#327

## How Has This Been Tested?
run tests, manual testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
