### PR TITLE
Fallback to device pin when Touch/Face ID is unavailable

### DIFF
--- a/MobileWallet/Common/Extensions/LAContext.swift
+++ b/MobileWallet/Common/Extensions/LAContext.swift
@@ -50,7 +50,7 @@ extension LAContext {
     var biometricType: BiometricType {
         var error: NSError?
 
-        guard self.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
+        guard self.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) else {
             // Capture these recoverable error thru Crashlytics
             return .none
         }
@@ -67,7 +67,7 @@ extension LAContext {
                 fatalError()
             }
         } else {
-            return  self.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) ? .touchID : .none
+            return  self.canEvaluatePolicy(.deviceOwnerAuthentication, error: nil) ? .touchID : .none
         }
     }
 }

--- a/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
@@ -904,11 +904,11 @@ class WalletCreationViewController: UIViewController {
             let context = LAContext()
             var error: NSError?
 
-            if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics,
+            if context.canEvaluatePolicy(.deviceOwnerAuthentication,
                                          error: &error) {
                 let reason = secondLabelTop.text ?? ""
 
-                context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) {
+                context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) {
                     [weak self] success, _ in
 
                     DispatchQueue.main.async { [weak self] in


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a user hasn't enrolled Face ID or TouchID then fallback to device pin right away for local authentication.

## Motivation and Context
<!--- What feature is it related to? Why is this change required? What problem does it solve?-->
<!--- If it fixes an open issue or closes a feature ticket, please link to the issue here. -->
Related to https://github.com/tari-project/wallet-ios/issues/212

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->
Using simulators that have not enrolled in biometrics and a iPhone 7 with broken touch ID.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
