### PR TITLE
Showing the tx state from the start

### DIFF
--- a/MobileWallet/Screens/Home/Transaction/TransactionViewControllerExtension.swift
+++ b/MobileWallet/Screens/Home/Transaction/TransactionViewControllerExtension.swift
@@ -47,7 +47,7 @@ extension TransactionViewController {
         navigationBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
         navigationBar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
         navigationBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
-        navigationBarHeightAnchor = navigationBar.heightAnchor.constraint(equalToConstant: TransactionViewController.defaultNavBarHeight)
+        navigationBarHeightAnchor = navigationBar.heightAnchor.constraint(equalToConstant: navBarHeightConstant)
         navigationBarHeightAnchor.isActive = true
     }
 
@@ -236,7 +236,6 @@ extension TransactionViewController {
     }
 
     func setupCancelButton() {
-        cancelButton.alpha = 0
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
         navigationBar.addSubview(cancelButton)
         cancelButton.bottomAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: 0).isActive = true

--- a/MobileWallet/UIElements/NavigationBarWithSubtitle.swift
+++ b/MobileWallet/UIElements/NavigationBarWithSubtitle.swift
@@ -78,12 +78,17 @@ class NavigationBarWithSubtitle: UIView, NavigationBarWithSubtitleProtocol {
         clipsToBounds = true
         layer.masksToBounds = false
 
-        let animation = CABasicAnimation(keyPath: "shadowOpacity")
-        animation.fromValue = layer.shadowOpacity
-        animation.toValue = 0.1
-        animation.duration = CATransaction.animationDuration()
-        layer.add(animation, forKey: animation.keyPath)
-        layer.shadowOpacity = 0.1
+        //The shadow seems to be mistakenly added to all subviews briefly after loading.
+        //TODO figure out why this is happening so we can remove this delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: { [weak self] in
+            guard let self = self else { return }
+            let animation = CABasicAnimation(keyPath: "shadowOpacity")
+            animation.fromValue = self.layer.shadowOpacity
+            animation.toValue = 0.1
+            animation.duration = 0.25
+            self.layer.add(animation, forKey: animation.keyPath)
+            self.layer.shadowOpacity = 0.1
+        })
 
         setupTitle()
         setupSubtitle()


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Show the transaction state in the navigation bar from the start instead of animating it in after loading the view.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
