### PR TITLE
Prevents multiple debug log screens.

### DIFF
--- a/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
@@ -614,7 +614,7 @@ class WalletCreationViewController: UIViewController {
             }
         )
     }
-    
+
     private func showNumpadView() {
         radialGradient.isHidden = true
         numpadImageView.isHidden = false
@@ -960,7 +960,7 @@ class WalletCreationViewController: UIViewController {
                             alert.addAction(UIAlertAction(title: NSLocalizedString("Try again", comment: "Try again button"),
                                                           style: .default,
                                                           handler: nil))
-                            
+
                             self.present(alert, animated: true, completion: nil)
                         }
                     }
@@ -972,11 +972,11 @@ class WalletCreationViewController: UIViewController {
                 alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel button"),
                                               style: .cancel,
                                               handler: nil))
-                
+
                 alert.addAction(UIAlertAction(title: NSLocalizedString("Proceed", comment: "Proceed button"), style: .default, handler: { [weak self] _ in
                     self?.hideLocalAuthentification()
                 }))
-                
+
                 self.present(alert, animated: true, completion: nil)
             }
         case .enableNotifications:

--- a/MobileWallet/Screens/Debug/UIViewControllerDebugExtension.swift
+++ b/MobileWallet/Screens/Debug/UIViewControllerDebugExtension.swift
@@ -90,6 +90,9 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
     }
 
     private func showTariLibLogs() {
+        if navigationController?.topViewController is DebugLogsTableViewController {
+            return
+        }
         let logsVC = DebugLogsTableViewController()
 
         self.navigationController?.view.layer.add(Theme.shared.transitions.pullDownOpen, forKey: kCATransition)


### PR DESCRIPTION
## Description
Prevents the debug menu to open up multiple instances of the debug log screen.

## Motivation and Context
tari-project/wallet-ios#346

## How Has This Been Tested?
Ran on multiple sims and a device.

## Screenshots and/or video clip
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
