### PR TITLE
Deep link params for populating transaction amount and note

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -141,6 +141,10 @@
 		009BF8AC237ABB4700C02E44 /* TariLib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009BF8AB237ABB4700C02E44 /* TariLib.swift */; };
 		009BF8AD237ABB4700C02E44 /* TariLib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009BF8AB237ABB4700C02E44 /* TariLib.swift */; };
 		009BF8AE237ABB4700C02E44 /* TariLib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009BF8AB237ABB4700C02E44 /* TariLib.swift */; };
+		009DFCA72473E33F0061DBC9 /* DeepLinkParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009DFCA62473E33F0061DBC9 /* DeepLinkParams.swift */; };
+		009DFCA82473EBCB0061DBC9 /* DeepLinkParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009DFCA62473E33F0061DBC9 /* DeepLinkParams.swift */; };
+		009DFCA92473ECCB0061DBC9 /* DeepLinkParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009DFCA62473E33F0061DBC9 /* DeepLinkParams.swift */; };
+		009DFCAA2473ECCB0061DBC9 /* DeepLinkParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009DFCA62473E33F0061DBC9 /* DeepLinkParams.swift */; };
 		00A057AF23D875840029C22A /* TariEventBus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A057AE23D875840029C22A /* TariEventBus.swift */; };
 		00A057B023D875840029C22A /* TariEventBus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A057AE23D875840029C22A /* TariEventBus.swift */; };
 		00A057B123D875840029C22A /* TariEventBus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A057AE23D875840029C22A /* TariEventBus.swift */; };
@@ -533,6 +537,7 @@
 		009BF8A8237AA13500C02E44 /* Biometrics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Biometrics.m; sourceTree = "<group>"; };
 		009BF8A9237AA13500C02E44 /* Biometrics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Biometrics.h; sourceTree = "<group>"; };
 		009BF8AB237ABB4700C02E44 /* TariLib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TariLib.swift; sourceTree = "<group>"; };
+		009DFCA62473E33F0061DBC9 /* DeepLinkParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkParams.swift; sourceTree = "<group>"; };
 		00A057AE23D875840029C22A /* TariEventBus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TariEventBus.swift; sourceTree = "<group>"; };
 		00A057B323D979DA0029C22A /* UserFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedback.swift; sourceTree = "<group>"; };
 		00A66516243772A70046E730 /* pendingTx.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = pendingTx.json; sourceTree = "<group>"; };
@@ -836,6 +841,7 @@
 				00F53A632428E44700448466 /* StorageCleanup.swift */,
 				619190C6EBD050DC647D1D7B /* UTXO.swift */,
 				00A66526243C766D0046E730 /* ConnectionMonitor.swift */,
+				009DFCA62473E33F0061DBC9 /* DeepLinkParams.swift */,
 			);
 			name = Utils;
 			path = Wrappers/Utils;
@@ -1801,6 +1807,7 @@
 				00C520B82469720F0077BF7F /* Sequence.swift in Sources */,
 				00C520D02469721D0077BF7F /* TransactionProtocol.swift in Sources */,
 				00C520BD2469720F0077BF7F /* BaseNode.swift in Sources */,
+				009DFCAA2473ECCB0061DBC9 /* DeepLinkParams.swift in Sources */,
 				00C520CD246972180077BF7F /* PendingOutboundTransactions.swift in Sources */,
 				00C520CF246972180077BF7F /* PendingInboundTransactions.swift in Sources */,
 				00C520BF2469720F0077BF7F /* UTXO.swift in Sources */,
@@ -1857,6 +1864,7 @@
 				00BCE489240EB1EE00B181F3 /* SplashViewControllerSetup.swift in Sources */,
 				006D211D23CEDF16007D1C10 /* MicroTari.swift in Sources */,
 				00BBD812237E9EE200EBF5E6 /* PrivateKey.swift in Sources */,
+				009DFCA72473E33F0061DBC9 /* DeepLinkParams.swift in Sources */,
 				001F6CE02380198D00FA7002 /* Contacts.swift in Sources */,
 				00BBD80E237DA07400EBF5E6 /* ByteVector.swift in Sources */,
 				00BBD81A237EB31900EBF5E6 /* CommsConfig.swift in Sources */,
@@ -1947,6 +1955,7 @@
 				BFD758E723E98ABD00B0F1A5 /* ProfileViewController.swift in Sources */,
 				00BBD802237C5B5200EBF5E6 /* CommandLineArgs.swift in Sources */,
 				0091D4A823ED879E004BF7F7 /* Signature.swift in Sources */,
+				009DFCA82473EBCB0061DBC9 /* DeepLinkParams.swift in Sources */,
 				00DD1610241CD42500C955B4 /* BaseNode.swift in Sources */,
 				37547D5724601BF600EB59CC /* UIView+GlobalFrame.swift in Sources */,
 				006D211E23CEDF16007D1C10 /* MicroTari.swift in Sources */,
@@ -2029,6 +2038,7 @@
 				00BBD81C237EB31900EBF5E6 /* CommsConfig.swift in Sources */,
 				004277FD23E1A61F00AE7BD9 /* ErrorDescriptions.swift in Sources */,
 				00BBD818237EA67600EBF5E6 /* Wallet.swift in Sources */,
+				009DFCA92473ECCB0061DBC9 /* DeepLinkParams.swift in Sources */,
 				004277F923E0628A00AE7BD9 /* UIViewController.swift in Sources */,
 				001F6CE22380198D00FA7002 /* Contacts.swift in Sources */,
 				00BBD810237DA07400EBF5E6 /* ByteVector.swift in Sources */,

--- a/MobileWallet/Common/DeepLinkManager.swift
+++ b/MobileWallet/Common/DeepLinkManager.swift
@@ -109,7 +109,8 @@ class DeeplinkNavigator {
             if let deeplink = link {
                 do {
                     let pubKey = try PublicKey(deeplink: deeplink)
-                    homeVC.onSend(pubKey: pubKey)
+                    let params = try DeepLinkParams(deeplink: deeplink)
+                    homeVC.onSend(pubKey: pubKey, deepLinkParams: params)
                 } catch {
                     UserFeedback.shared.error(
                         title: NSLocalizedString("Invalid link found", comment: "Deep link error"),

--- a/MobileWallet/Common/NotificationManager.swift
+++ b/MobileWallet/Common/NotificationManager.swift
@@ -152,8 +152,6 @@ class NotificationManager {
 
         TariLogger.verbose("Registering device token with public key")
 
-        print("TODO: ", apnsDeviceToken)
-
         do {
             let signature = try signRequestMessage(apnsDeviceToken)
 

--- a/MobileWallet/SceneDelegate.swift
+++ b/MobileWallet/SceneDelegate.swift
@@ -57,9 +57,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         //If the user opens a deep link while the app is closed
         if let url = connectionOptions.urlContexts.first?.url {
-            if let deeplink = NSString(string: url.absoluteString).removingPercentEncoding {
-                deepLinker.handleShortcut(type: .send(deeplink: deeplink))
-            }
+            deepLinker.handleShortcut(type: .send(deeplink: NSString(string: url.absoluteString) as String))
         }
 
         //If the user opens a home screen shortcut while the app is closed
@@ -78,11 +76,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         if let url = URLContexts.first?.url {
-            guard let deeplink = NSString(string: url.absoluteString).removingPercentEncoding else {
-                return
-            }
-
-            deepLinker.handleShortcut(type: .send(deeplink: deeplink))
+            deepLinker.handleShortcut(type: .send(deeplink: NSString(string: url.absoluteString) as String))
         }
     }
 

--- a/MobileWallet/Screens/Home/HomeViewController.swift
+++ b/MobileWallet/Screens/Home/HomeViewController.swift
@@ -412,13 +412,14 @@ class HomeViewController: UIViewController, FloatingPanelControllerDelegate, Tra
         onSend()
     }
 
-    func onSend(pubKey: PublicKey? = nil) {
+    func onSend(pubKey: PublicKey? = nil, deepLinkParams: DeepLinkParams? = nil) {
         let sendVC = AddRecipientViewController()
 
         //This is used by the deep link manager
         if let publicKey = pubKey {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: { [weak self] in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.75, execute: { [weak self] in
                 guard let _ = self else { return }
+                sendVC.deepLinkParams = deepLinkParams
                 sendVC.onAdd(publicKey: publicKey)
             })
         }

--- a/MobileWallet/Screens/Send/AddAmount/AddAmountViewController.swift
+++ b/MobileWallet/Screens/Send/AddAmount/AddAmountViewController.swift
@@ -42,6 +42,7 @@ import UIKit
 
 class AddAmountViewController: UIViewController {
     var publicKey: PublicKey?
+    var deepLinkParams: DeepLinkParams?
     private var buttons = [UIButton]()
     private let continueButton = ActionButton(frame: .zero)
     private let amountLabel = AnimatedBalanceLabel()
@@ -79,6 +80,13 @@ class AddAmountViewController: UIViewController {
 
         guard let wallet = TariLib.shared.tariWallet, let pubKey = publicKey else {
             return
+        }
+
+        //Deep link value
+        if let params = deepLinkParams {
+            if params.amount.rawValue > 0 {
+                addCharacater(params.amount.formatted)
+            }
         }
 
         do {
@@ -373,6 +381,7 @@ class AddAmountViewController: UIViewController {
         let noteVC = AddNoteViewController()
         noteVC.publicKey = publicKey
         noteVC.amount = tariAmount
+        noteVC.deepLinkParams = deepLinkParams
 
         navigationController?.pushViewController(noteVC, animated: true)
     }

--- a/MobileWallet/Screens/Send/AddNote/AddNoteViewController.swift
+++ b/MobileWallet/Screens/Send/AddNote/AddNoteViewController.swift
@@ -43,6 +43,7 @@ import UIKit
 class AddNoteViewController: UIViewController, UITextViewDelegate, SlideViewDelegate {
     var publicKey: PublicKey?
     var amount: MicroTari?
+    var deepLinkParams: DeepLinkParams?
     private let SIDE_PADDING = Theme.shared.sizes.appSidePadding
 
     fileprivate let sendButton = SlideView()
@@ -102,6 +103,11 @@ class AddNoteViewController: UIViewController, UITextViewDelegate, SlideViewDele
 
         noteInput.becomeFirstResponder()
         navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+
+        if let params = deepLinkParams {
+            noteInput.text = params.note
+            textViewDidChangeSelection(noteInput)
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/MobileWallet/Screens/Send/AddRecipient/AddRecipientViewController.swift
+++ b/MobileWallet/Screens/Send/AddRecipient/AddRecipientViewController.swift
@@ -55,6 +55,7 @@ class AddRecipientViewController: UIViewController, UITextFieldDelegate, Contact
     private var pasteEmojisViewBottomAnchorConstraint = NSLayoutConstraint()
     private let dimView = UIView()
     private var currentTextInputContent = "" //Used to check if something actually changed to avoid unnecessary ffi calls
+    var deepLinkParams: DeepLinkParams?
 
     private var isEditingSearchBox: Bool = false {
         didSet {
@@ -463,6 +464,7 @@ class AddRecipientViewController: UIViewController, UITextFieldDelegate, Contact
     @objc private func onContinue() {
         let amountVC = AddAmountViewController()
         amountVC.publicKey = selectedRecipientPublicKey
+        amountVC.deepLinkParams = deepLinkParams
         self.navigationController?.pushViewController(amountVC, animated: true)
     }
 

--- a/MobileWallet/TariLib/Wrappers/PublicKey.swift
+++ b/MobileWallet/TariLib/Wrappers/PublicKey.swift
@@ -169,7 +169,7 @@ class PublicKey {
 
     //Accepts deep links using either emoji ID or hex. i.e:
     //tari://rincewind/eid/🖖🥴😍🙃💦🤘🤜👁🙃🙌😱🖐🙀🤳🖖👍✊🐈☂💀👚😶🤟😳👢😘😺🙌🎩🤬🐼😎🥺
-    //tari://rincewind/pubkey/70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a
+    //tari://rincewind/pubkey/70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a?amount=2.3note=hi%20there
     convenience init(deeplink: String) throws {
         guard deeplink.hasPrefix("\(TariSettings.shared.deeplinkURI)://") else {
             throw PublicKeyError.invalidDeepLink
@@ -182,14 +182,14 @@ class PublicKey {
             throw PublicKeyError.invalidDeepLinkNetwork
         }
 
-        if deeplink.hasPrefix("\(deeplinkPrefix)/eid/") {
-            //TODO this might not work once we add url params for alias and amount
-            let emojis = deeplink.replacingOccurrences(of: "\(deeplinkPrefix)/eid/", with: "")
+        let strippedParamsLink = PublicKey.removeDeepURLParams(deeplink)
+
+        if strippedParamsLink.hasPrefix("\(deeplinkPrefix)/eid/") {
+            let emojis = strippedParamsLink.replacingOccurrences(of: "\(deeplinkPrefix)/eid/", with: "")
             try self.init(emojis: emojis)
             return
-        } else if deeplink.hasPrefix("\(deeplinkPrefix)/pubkey/") {
-            //TODO this might not work once we add url params for alias and amount
-            let hex = deeplink.replacingOccurrences(of: "\(deeplinkPrefix)/pubkey/", with: "")
+        } else if strippedParamsLink.hasPrefix("\(deeplinkPrefix)/pubkey/") {
+            let hex = strippedParamsLink.replacingOccurrences(of: "\(deeplinkPrefix)/pubkey/", with: "")
             try self.init(hex: hex)
             return
         }
@@ -227,6 +227,19 @@ class PublicKey {
 
     init(pointer: OpaquePointer) {
         ptr = pointer
+    }
+
+    private static func removeDeepURLParams(_ link: String) -> String {
+        guard let startIndex = link.lastIndex(of: "?") else {
+            return link
+        }
+
+        let endIndex = link.index(link.endIndex, offsetBy: -1)
+
+        var strippedLink = link
+        strippedLink.removeSubrange(startIndex...endIndex)
+
+        return strippedLink
     }
 
     private static func containsEmojis(_ text: String) -> Bool {

--- a/MobileWallet/TariLib/Wrappers/Utils/DeepLinkParams.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/DeepLinkParams.swift
@@ -1,0 +1,84 @@
+//  DeepLinkParams.swift
+
+/*
+	Package MobileWallet
+	Created by Jason van den Berg on 2020/05/19
+	Using Swift 5.0
+	Running on macOS 10.15
+
+	Copyright 2019 The Tari Project
+
+	Redistribution and use in source and binary forms, with or
+	without modification, are permitted provided that the
+	following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above
+	copyright notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	3. Neither the name of the copyright holder nor the names of
+	its contributors may be used to endorse or promote products
+	derived from this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+	CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+	CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+	OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+enum DeepLinkParamsError: Error {
+    case invalidURL
+}
+
+struct DeepLinkParams {
+    let amount: MicroTari
+    let note: String
+
+    init(deeplink: String) throws {
+        var defaultNote = ""
+        var defaultAmount = MicroTari(0)
+
+        guard let url = URL(string: deeplink) else {
+            throw DeepLinkParamsError.invalidURL
+        }
+
+        let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        if let items = (urlComponents?.queryItems) as [NSURLQueryItem]? {
+            items.forEach { (item) in
+                switch item.name {
+                case "note":
+                    if let noteValue = item.value {
+                        defaultNote = noteValue
+                    }
+                case "amount":
+                      if let amountFormatted = item.value {
+                        if let d = Double(amountFormatted) {
+                            if let microTariAmount = try? MicroTari(decimalValue: d) {
+                                defaultAmount = microTariAmount
+                            }
+                        }
+                      }
+                default:
+                    break
+                }
+            }
+        }
+
+        note = defaultNote
+        amount = defaultAmount
+    }
+}

--- a/MobileWallet/TariLib/Wrappers/Utils/MicroTari.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/MicroTari.swift
@@ -146,6 +146,14 @@ struct MicroTari {
         self.rawValue = UInt64(tariNumber.floatValue * Float(MicroTari.CONVERSION))
     }
 
+    init(decimalValue: Double) throws {
+        guard let rawVal = UInt64(exactly: decimalValue * Double(MicroTari.CONVERSION)) else {
+            throw MicroTariErrors.invalidStringFormat //TODO
+        }
+
+        self.rawValue = rawVal
+    }
+
     public static func toTariNumber(_ number: NSNumber) -> UInt64 {
         return number.uint64Value * UInt64(CONVERSION)
     }

--- a/MobileWallet/TariLib/Wrappers/Wallet.swift
+++ b/MobileWallet/TariLib/Wrappers/Wallet.swift
@@ -460,8 +460,6 @@ class Wallet {
             throw WalletErrors.generic(errorCode)
         }
 
-        print("wallet_is_completed_transaction_outbound", result)
-
         return result
     }
 

--- a/MobileWalletTests/TariLibWrapperTests.swift
+++ b/MobileWalletTests/TariLibWrapperTests.swift
@@ -129,8 +129,12 @@ class TariLibWrapperTests: XCTestCase {
         XCTAssertThrowsError(try PublicKey(emojis: "🐒🐑🍔🔧❌👂🦒💇🔋💥🍷🍺👔😷🐶🧢🤩💥🎾🎲🏀🤠💪👮🤯🎁💉🌞🍉🤷🍦👽👽"))
         
         //Valid deep links
-        XCTAssertNoThrow(try PublicKey(deeplink: "\(TariSettings.shared.deeplinkURI)://\(TariSettings.shared.network)/eid/🐒🐑🍔🔧❌👂🦒💇🔋💥🍷🍺👔😷🐶🧢🤩💥🎾🎲🏀🤠💪👮🤯🎁💉🌞🍉🤷🍦👽🔈"))
+        XCTAssertNoThrow(try PublicKey(deeplink: "\(TariSettings.shared.deeplinkURI)://\(TariSettings.shared.network)/eid/🐒🐑🍔🔧❌👂🦒💇🔋💥🍷🍺👔😷🐶🧢🤩💥🎾🎲🏀🤠💪👮🤯🎁💉🌞🍉🤷🍦👽🔈")
+        )
+        XCTAssertNoThrow(try PublicKey(deeplink: "\(TariSettings.shared.deeplinkURI)://\(TariSettings.shared.network)/eid/🐒🐑🍔🔧❌👂🦒💇🔋💥🍷🍺👔😷🐶🧢🤩💥🎾🎲🏀🤠💪👮🤯🎁💉🌞🍉🤷🍦👽🔈?amount=32.1&note=hi%20there")
+        )
         XCTAssertNoThrow(try PublicKey(deeplink: "\(TariSettings.shared.deeplinkURI)://\(TariSettings.shared.network)/pubkey/70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a"))
+        XCTAssertNoThrow(try PublicKey(deeplink: "\(TariSettings.shared.deeplinkURI)://\(TariSettings.shared.network)/pubkey/70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a?amount=32.1note=hi%20there"))
         //Derive a deep link from random pubkey, then init a pubkey using that deep link
         XCTAssertNoThrow(try PublicKey(deeplink: PublicKey(privateKey: PrivateKey()).emojiDeeplink.0))
         XCTAssertNoThrow(try PublicKey(deeplink: PublicKey(privateKey: PrivateKey()).hexDeeplink.0))
@@ -149,6 +153,16 @@ class TariLibWrapperTests: XCTestCase {
         XCTAssertNoThrow(try PublicKey(any: "My emojis are \"🐒🐑🍔🔧❌👂🦒💇🔋💥🍷🍺👔😷🐶🧢🤩💥🎾🎲🏀🤠💪👮🤯🎁💉🌞🍉🤷🍦👽🔈\""))
         XCTAssertNoThrow(try PublicKey(any: "🐒🐑🍔🔧❌👂🦒💇🔋💥🍷🍺👔😷🐶🧢🤩 bla bla bla 💥🎾🎲🏀🤠💪👮🤯🎁💉🌞🍉🤷🍦👽🔈"))
         XCTAssertNoThrow(try PublicKey(any: "My emojis 🐒🐑🍔🔧❌👂🦒💇🔋💥🍷🍺👔😷🐶 and here are the rest 🧢🤩💥🎾🎲🏀🤠💪👮🤯🎁💉🌞🍉🤷🍦👽🔈"))
+    }
+    
+    func testDeepLink() {
+        do {
+           let params = try DeepLinkParams(deeplink: "\(TariSettings.shared.deeplinkURI)://\(TariSettings.shared.network)/pubkey/70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a?amount=60.50&note=hi%20there")
+
+            XCTAssertEqual(60500000, params.amount.rawValue)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
     }
     
     func testBaseNode() {
@@ -405,5 +419,8 @@ class TariLibWrapperTests: XCTestCase {
         XCTAssert(MicroTari.convertToString(NSNumber(10.0), minimumFractionDigits: 0) == "10")
         XCTAssertNoThrow(try MicroTari(tariValue: "1234567898"))
         XCTAssertThrowsError(try MicroTari(tariValue: "1234567898765432123567")) //Too large to be converted to uint64 in micro tari
+        XCTAssertNoThrow(try MicroTari(decimalValue: 2))
+        XCTAssertNoThrow(try MicroTari(decimalValue: 1.1234))
+        XCTAssertThrowsError(try MicroTari(decimalValue: 0.123456789))
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- Stripping out url params when constructing a public key from a deep link
- Deep link params used to pre populate amount and note for a tx

## Motivation and Context
<!--- What feature is it related to? Why is this change required? What problem does it solve?-->
<!--- If it fixes an open issue or closes a feature ticket, please link to the issue here. -->
More convenient for users buying from the TTL store.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with unit tests.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added/changed tests to cover my changes if not UI changes.
