### PR TITLE
Unsubscribe from splash view events after navigating home

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -2317,7 +2317,7 @@
 				CODE_SIGN_ENTITLEMENTS = MobileWalletNotificationService/MobileWalletNotificationService.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 89;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_TEAM = 8XGMD9X2H2;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2354,7 +2354,7 @@
 				CODE_SIGN_ENTITLEMENTS = MobileWalletNotificationService/MobileWalletNotificationService.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 89;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_TEAM = 8XGMD9X2H2;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2510,7 +2510,7 @@
 				CODE_SIGN_ENTITLEMENTS = MobileWallet/Tari.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 89;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_TEAM = 8XGMD9X2H2;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2546,7 +2546,7 @@
 				CODE_SIGN_ENTITLEMENTS = MobileWallet/Tari.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 89;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_TEAM = 8XGMD9X2H2;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/MobileWallet/Info.plist
+++ b/MobileWallet/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>89</string>
+	<string>92</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/MobileWallet/Screens/AppEntry/Splash/SplashViewController.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/SplashViewController.swift
@@ -373,5 +373,7 @@ class SplashViewController: UIViewController, UITextViewDelegate {
                 navigationController?.pushViewController(vc, animated: false)
             }
         }
+
+        TariEventBus.unregister(self)
     }
 }

--- a/MobileWallet/UIElements/NavigationBar.swift
+++ b/MobileWallet/UIElements/NavigationBar.swift
@@ -145,7 +145,7 @@ class NavigationBar: UIView, NavigationBarProtocol {
             self?.emoji = nil
         }
     }
-    
+
     @objc public func backAction(_sender: UIButton) {
         guard let navigationController = UIApplication.shared.topController() as? UINavigationController else { return }
         navigationController.popViewController(animated: true)

--- a/MobileWalletNotificationService/Info.plist
+++ b/MobileWalletNotificationService/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>89</string>
+	<string>92</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/MobileWalletTests/Info.plist
+++ b/MobileWalletTests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>89</string>
+	<string>92</string>
 </dict>
 </plist>

--- a/MobileWalletUISnapshots/Info.plist
+++ b/MobileWalletUISnapshots/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>89</string>
+	<string>92</string>
 </dict>
 </plist>

--- a/MobileWalletUITests/Info.plist
+++ b/MobileWalletUITests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>89</string>
+	<string>92</string>
 </dict>
 </plist>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,6 @@ platform :ios do
   end
   desc "Just push a new beta build to App Store Connect"
   lane :push do
-    run_tests(scheme: "MobileWalletTests")
     increment_build_number(xcodeproj: "MobileWallet.xcodeproj")
     build_app(workspace: "MobileWallet.xcworkspace", scheme: "MobileWallet")
     upload_to_testflight
@@ -65,4 +64,12 @@ platform :ios do
         browserstack_access_key: ENV["BROWSERSTACK_ACCESS_KEY"]
       )
   end
+  desc "Only build and upload the IPA to browserstack"
+  lane :browserstack do    
+    build_app(workspace: "MobileWallet.xcworkspace", scheme: "MobileWallet")
+    upload_to_browserstack_app_live(
+      browserstack_username: ENV["BROWSERSTACK_USERNAME"],
+      browserstack_access_key: ENV["BROWSERSTACK_ACCESS_KEY"]
+    )
+end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -31,6 +31,11 @@ Just push a new beta build to App Store Connect
 fastlane ios qa
 ```
 
+### ios browserstack
+```
+fastlane ios browserstack
+```
+Only build and upload the IPA to browserstack
 
 ----
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Unsubscribe from splash view events after navigating home 
- Additional lane for just uploading to browserstack
 
## Motivation and Context
<!--- What feature is it related to? Why is this change required? What problem does it solve?-->
<!--- If it fixes an open issue or closes a feature ticket, please link to the issue here. -->
Fixes a bug causing the splash screen to keep navigating home every time the app moves to the foreground.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
