### PR TITLE
emojiID paste banner fix

### DIFF
--- a/MobileWallet/Screens/Send/AddRecipient/AddRecipientViewController.swift
+++ b/MobileWallet/Screens/Send/AddRecipient/AddRecipientViewController.swift
@@ -398,11 +398,14 @@ class AddRecipientViewController: UIViewController, UITextFieldDelegate, Contact
 
         let pasteboardString: String? = UIPasteboard.general.string
 
-        if let text = pasteboardString {
+        if var text = pasteboardString {
             //Try get a pubkey from clipboard text
             do {
-                let pubKeyFromDeeplink = try PublicKey(any: text)
-                clipboardEmojis = pubKeyFromDeeplink.emojis.0
+                if !text.hasPrefix("\(TariSettings.shared.deeplinkURI)://") {
+                    text = text.emojiString
+                }
+                let pubKey = try PublicKey(any: text)
+                clipboardEmojis = pubKey.emojis.0
                 return
             } catch {
                //No valid pubkey found


### PR DESCRIPTION

## Description
added getting only emoji string from UIPasteboard string for "paste" banner

## Motivation and Context
tari-project/wallet-ios#421

## How Has This Been Tested?
run test, manual testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
