### PR TITLE
Matomo fixes.

### DIFF
--- a/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
@@ -106,6 +106,7 @@ class WalletCreationViewController: UIViewController {
         state = .localAuthentication
         prepareSubviews(for: .localAuthentication)
         showLocalAuthentication()
+        Tracker.shared.track("/local_auth", "Local Authentication")
     }
 
     // MARK: - Actions

--- a/MobileWallet/Screens/Send/AddNote/AddNoteViewController.swift
+++ b/MobileWallet/Screens/Send/AddNote/AddNoteViewController.swift
@@ -178,7 +178,10 @@ class AddNoteViewController: UIViewController, UITextViewDelegate, SlideViewDele
     func slideViewDidFinish(_ sender: SlideView) {
         dismissKeyboard()
 
-        Tracker.shared.track(eventWithCategory: "Transaction", action: "User completes \("Slide to Send") on Notes screen", name: "Transaction Initiated")
+        Tracker.shared.track(
+            eventWithCategory: "Transaction",
+            action: "Transaction Initiated"
+        )
 
         guard let wallet = TariLib.shared.tariWallet else {
             UserFeedback.shared.error(

--- a/MobileWallet/Screens/Send/SendingTari/SendingTariViewController.swift
+++ b/MobileWallet/Screens/Send/SendingTari/SendingTariViewController.swift
@@ -181,6 +181,8 @@ class SendingTariViewController: UIViewController {
         progressBar1View.alpha = 0
         progressBar2View.alpha = 0
         progressBar3View.alpha = 0
+        
+        Tracker.shared.track("/home/send_tari/finalize", "Send Tari - Finalize")
     }
 
     override func viewDidLayoutSubviews() {
@@ -654,8 +656,7 @@ class SendingTariViewController: UIViewController {
                 self.sendPushNotificationToRecipient()
                 Tracker.shared.track(
                     eventWithCategory: "Transaction",
-                    action: "User's transaction sent synchronously",
-                    name: "Transaction Accepted - Synchronous"
+                    action: "Transaction Accepted - Synchronous"
                 )
                 TariEventBus.unregister(self)
                 // direct send successful
@@ -679,8 +680,7 @@ class SendingTariViewController: UIViewController {
                 self.sendPushNotificationToRecipient()
                 Tracker.shared.track(
                     eventWithCategory: "Transaction",
-                    action: "User's transaction is \("stored") after discovery times out",
-                    name: "Transaction Stored"
+                    action: "Transaction Stored"
                 )
                 TariEventBus.unregister(self)
                 // store and forward send successful
@@ -738,13 +738,13 @@ class SendingTariViewController: UIViewController {
         ) {
             [weak self] _ in
             // display error
-            self?.displayErrorFeedback()
+            self?.displayErrorFeedbackAndTrackEvent()
             // return to home
             self?.navigationController?.popToRootViewController(animated: false)
         }
     }
 
-    private func displayErrorFeedback() {
+    private func displayErrorFeedbackAndTrackEvent() {
         guard let completionStatus = completionStatus else { return }
         switch completionStatus {
         case .internetConnectionError:
@@ -758,6 +758,10 @@ class SendingTariViewController: UIViewController {
                     comment: "Internet connection error when sending a tx"
                 )
             )
+            Tracker.shared.track(
+                eventWithCategory: "Transaction",
+                action: "Transaction Failed - Tor Issue"
+            )
         case .networkConnectionTimeout, .sendError:
             UserFeedback.shared.error(
                 title: NSLocalizedString(
@@ -768,6 +772,10 @@ class SendingTariViewController: UIViewController {
                     "Looks like there's a connectivity issue on our end. Can you give us a few min, then come back and try again?",
                     comment: "Tari network connection error when sending a tx"
                 )
+            )
+            Tracker.shared.track(
+                eventWithCategory: "Transaction",
+                action: "Transaction Failed - Node Issue"
             )
         default:
             break


### PR DESCRIPTION
Add a missing page tracking. Structure event calls so they produce the same data as Android. Solution for tari-project/wallet-ios#261.

## Description
Matomo Android API doesn't have the `name` parameter, so `action` parameter is used for the event name. This PR updates the code to make the event data the same on both platforms.

## Motivation and Context
tari-project/wallet-ios#261 and tari-project/wallet-android#271.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [ ] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
