### PR TITLE
Using the old emoji set to show an error message

### DIFF
--- a/MobileWallet/TariLib/Wrappers/PublicKey.swift
+++ b/MobileWallet/TariLib/Wrappers/PublicKey.swift
@@ -130,6 +130,7 @@ class PublicKey {
             .replacingOccurrences(of: "|", with: "")
             .replacingOccurrences(of: "`", with: "")
             .replacingOccurrences(of: " ", with: "")
+
         if cleanEmojis.count < PublicKey.emojiCount {
             throw PublicKeyError.invalidEmojis
         }
@@ -149,6 +150,7 @@ class PublicKey {
         guard errorCode == 0 else {
             throw PublicKeyError.generic(errorCode)
         }
+
         ptr = result!
     }
 
@@ -223,11 +225,12 @@ class PublicKey {
             do {
                 try self.init(emojis: filteredEmojis)
                 return
-            } catch {
-                if filteredEmojis.count == PublicKey.emojiCount {
-                    throw PublicKeyError.invalidEmojiSet
-                }
-            }
+            } catch {}
+        }
+
+        //User might have an emoji ID from an outdated set
+        if PublicKey.isOldEmojiSet(any) {
+            throw PublicKeyError.invalidEmojiSet
         }
 
         throw PublicKeyError.cantDerivePublicKeyFromString
@@ -250,16 +253,6 @@ class PublicKey {
         return strippedLink
     }
 
-    private static func containsEmojis(_ text: String) -> Bool {
-        for scalar in text.unicodeScalars {
-            if scalar.properties.isEmoji {
-                return true
-            }
-        }
-
-        return false
-    }
-
     private static func filterEmojis(_ text: String) -> String {
         var emojis = ""
 
@@ -272,6 +265,41 @@ class PublicKey {
         }
 
         return emojis
+    }
+
+    private static func isOldEmojiSet(_ text: String) -> Bool {
+        let oldEmojiSet = [
+            "😀", "😂", "🤣", "😉", "😊", "😎", "😍", "😘", "🤗", "🤩", "🤔", "🙄", "😮", "🤐", "😴", "😛", "🤤", "🙃", "🤑",
+            "😤", "😨", "🤯", "😬", "😱", "🤪", "😵", "😷", "🤢", "🤮", "🤠", "🤡", "🤫", "🤭", "🤓", "😈", "👻", "👽", "🤖",
+            "💩", "😺", "👶", "👩", "👨", "👮", "🤴", "👸", "🧜", "🙅", "🙋", "🤦", "🤷", "💇", "🏃", "💃", "🧗", "🛀", "🛌",
+            "👤", "🏄", "🚴", "🤹", "💏", "👪", "💪", "👈", "👍", "✋", "👊", "👐", "🙏", "🤝", "💅", "👂", "👀", "🧠", "👄",
+            "💔", "💖", "💙", "💌", "💤", "💣", "💥", "💦", "💨", "💫", "👔", "👕", "👖", "🧣", "🧤", "🧦", "👗", "👙", "👜",
+            "🎒", "👑", "🧢", "💍", "💎", "🐒", "🐶", "🦁", "🐴", "🦄", "🐮", "🐷", "🐑", "🐫", "🦒", "🐘", "🐭", "🐇", "🐔",
+            "🦆", "🐸", "🐍", "🐳", "🐚", "🦀", "🐌", "🦋", "🌸", "🌲", "🌵", "🍇", "🍉", "🍌", "🍎", "🍒", "🍓", "🥑", "🥕",
+            "🌽", "🍄", "🥜", "🍞", "🧀", "🍖", "🍔", "🍟", "🍕", "🍿", "🍦", "🍪", "🍰", "🍫", "🍬", "🍷", "🍺", "🍴", "🌍",
+            "🌋", "🏠", "⛺", "🎡", "🎢", "🎨", "🚂", "🚌", "🚑", "🚒", "🚔", "🚕", "🚜", "🚲", "⛽", "🚦", "🚧", "⛵", "🚢",
+            "🛫", "💺", "🚁", "🚀", "🛸", "🚪", "🚽", "🚿", "⌛", "⏰", "🕙", "🌛", "🌞", "⛅", "🌀", "🌈", "🌂", "🔥", "✨",
+            "🎈", "🎉", "🎀", "🎁", "🏆", "🏅", "⚽", "🏀", "🏈", "🎾", "🥊", "🎯", "⛳", "🎣", "🎮", "🎲", "🔈", "🔔", "🎶",
+            "🎤", "🎧", "📻", "🎸", "🎹", "🎺", "🎻", "🥁", "📱", "🔋", "💻", "📷", "🔍", "🔭", "📡", "💡", "🔦", "📖", "📚",
+            "📝", "📅", "📌", "📎", "🔒", "🔑", "🔨", "🏹", "🔧", "💉", "💊", "🏧", "⛔", "🚫", "✅", "❌", "❓", "❕", "💯",
+            "🆗", "🆘", "⬛", "🔶", "🔵", "🏁", "🚩", "🎌", "🏴"
+        ]
+
+        var cleanEmojis = ""
+
+        //Extract old emojis from string
+        for scalar in text.unicodeScalars {
+            if oldEmojiSet.contains(String(scalar)) {
+                cleanEmojis.append(Character(scalar))
+            }
+        }
+        print("cleanEmojis: ", cleanEmojis.count)
+
+        if cleanEmojis.count == PublicKey.emojiCount {
+            return true
+        }
+
+        return false
     }
 
     deinit {

--- a/MobileWalletTests/TariLibWrapperTests.swift
+++ b/MobileWalletTests/TariLibWrapperTests.swift
@@ -98,10 +98,10 @@ class TariLibWrapperTests: XCTestCase {
     func testPublicKey() {
         //Create pub key from hex, then create hex from that to test ByteVector toString()
         let originalPublicKeyHex = "6a493210f7499cd17fecb510ae0cea23a110e8d5b901f8acadd3095c73a3b919"
-        
+
         do {
             _ = try PublicKey(privateKey: PrivateKey())
-            
+
             let publicKey = try PublicKey(hex: originalPublicKeyHex)
             let (hex, hexError) = publicKey.hex
             if hexError != nil {
@@ -112,20 +112,20 @@ class TariLibWrapperTests: XCTestCase {
             if error != nil {
                 XCTFail(error!.localizedDescription)
             }
-            
+
             let emojiKey = try PublicKey(emojis: emojis)
             XCTAssertEqual(emojiKey.hex.0, publicKey.hex.0)
         } catch {
             XCTFail(error.localizedDescription)
         }
-        
+
         //Valid emoji ID
         XCTAssertNoThrow(try PublicKey(emojis: "🎳🐍💸🐼🐷💍🍔💤💘🔫😻💨🎩😱💭🎒🚧🐵🏉🔦🍴🎺🍺🐪🍕👔🍄🐍😇🌂🐑🍭😇"))
         XCTAssertNoThrow(try PublicKey(emojis: "🐘💉🔨🍆💈🏆💀🎩🍼🐍💀🎂🔱🐻🐑🔪🐖😹😻🚜🐭🎁🔔💩🚂🌠📡👅🏁🏭💔🎻🌊"))
-        
+
         //Invalid emoji ID
         XCTAssertThrowsError(try PublicKey(emojis: "🐒🐑🍔🔧❌👂🦒💇🔋💥🍷🍺👔😷🐶🧢🤩💥🎾🎲🏀🤠💪👮🤯🎁💉🌞🍉🤷🍦👽👽"))
-        
+
         //Valid deep links
         XCTAssertNoThrow(try PublicKey(deeplink: "\(TariSettings.shared.deeplinkURI)://\(TariSettings.shared.network)/eid/🎳🐍💸🐼🐷💍🍔💤💘🔫😻💨🎩😱💭🎒🚧🐵🏉🔦🍴🎺🍺🐪🍕👔🍄🐍😇🌂🐑🍭😇")
         )
@@ -142,7 +142,7 @@ class TariLibWrapperTests: XCTestCase {
         XCTAssertThrowsError(try PublicKey(deeplink: "\(TariSettings.shared.deeplinkURI)://\(TariSettings.shared.network)/eid/🖖🥴😍🙃💦🤘🤜👁🙃🙌😱"))
         XCTAssertThrowsError(try PublicKey(deeplink: "\(TariSettings.shared.deeplinkURI)://\(TariSettings.shared.network)/pubkey/invalid"))
         XCTAssertThrowsError(try PublicKey(deeplink: "\(TariSettings.shared.deeplinkURI)://made-up-net/pubkey/70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a"))
-        
+
         //Convenience init
         XCTAssertThrowsError(try PublicKey(any: "bla"))
         XCTAssertThrowsError(try PublicKey(any: "Hey use this emoji ID 🐒🐑🍔🔧❌👂🦒"))
@@ -151,13 +151,25 @@ class TariLibWrapperTests: XCTestCase {
         XCTAssertNoThrow(try PublicKey(any: "My emojis are \"🐘💉🔨🍆💈🏆💀🎩🍼🐍💀🎂🔱🐻🐑🔪🐖😹😻🚜🐭🎁🔔💩🚂🌠📡👅🏁🏭💔🎻🌊\""))
         XCTAssertNoThrow(try PublicKey(any: "🐘💉🔨🍆💈🏆💀🎩🍼🐍💀🎂🔱🐻🐑🔪🐖😹 bla bla bla 😻🚜🐭🎁🔔💩🚂🌠📡👅🏁🏭💔🎻🌊"))
         XCTAssertNoThrow(try PublicKey(any: "Please send me 1234. My emojis are 🎳🐍💸🐼🐷💍🍔💤💘 and here are the rest 🔫😻💨🎩😱💭🎒🚧🐵🏉🔦🍴🎺🍺🐪🍕👔🍄🐍😇🌂🐑🍭😇"))
-        
-        //Test deprecated emoji sets
+    }
+    
+    func testOldEmojiSet() {
         do {
-            _ = try PublicKey(any: "💨🎩😱😇🌂🐑😇🍭💭🎒🚧🐵🏉🔦🍴🎺🍺🐪🍕👔🍄🐍🎳🐍💸🐼🐷💍🍔💤💘🔫🎁")
+            _ = try PublicKey(any: "⚽🧣👂🤝🏧🐳🦄🎣😛🎻🏄🚧⛺🧠🔔🧢🍄💉🕙🐔🚪🧤🍪🚒🍌👊🥜👶🤪📎🐚🦀🍎")
         } catch {
             if case PublicKeyError.invalidEmojiSet = error {
                 //Correct error
+            } else {
+                XCTFail("Invalid emoji set should throw error")
+            }
+        }
+        
+        do {
+            _ = try PublicKey(any: "send me 12 ⚽🧣👂🤝🏧🐳🦄🎣😛🎻🏄🚧⛺🧠🔔🧢🍄💉🕙🐔🚪🧤🍪🚒🍌👊🥜👶🤪📎🐚🦀🍎")
+        } catch {
+            if case PublicKeyError.invalidEmojiSet = error {
+                //Correct error
+
             } else {
                 XCTFail("Invalid emoji set should throw error")
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
After changing the public key wrapper to use the emoji the from the FFI the error message was not displaying anymore. Replicated the android solution by including the old set to do the check.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->
Manually testing and fixing a unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
