### PR TITLE
Sandbox support for remote push notifications and shorter push reminders periods for testing

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -2499,7 +2499,7 @@
 				CODE_SIGN_ENTITLEMENTS = MobileWalletNotificationService/MobileWalletNotificationService.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 95;
+				CURRENT_PROJECT_VERSION = 98;
 				DEVELOPMENT_TEAM = 8XGMD9X2H2;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2536,7 +2536,7 @@
 				CODE_SIGN_ENTITLEMENTS = MobileWalletNotificationService/MobileWalletNotificationService.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 95;
+				CURRENT_PROJECT_VERSION = 98;
 				DEVELOPMENT_TEAM = 8XGMD9X2H2;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2692,7 +2692,7 @@
 				CODE_SIGN_ENTITLEMENTS = MobileWallet/Tari.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 95;
+				CURRENT_PROJECT_VERSION = 98;
 				DEVELOPMENT_TEAM = 8XGMD9X2H2;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2728,7 +2728,7 @@
 				CODE_SIGN_ENTITLEMENTS = MobileWallet/Tari.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 95;
+				CURRENT_PROJECT_VERSION = 98;
 				DEVELOPMENT_TEAM = 8XGMD9X2H2;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/MobileWallet/Common/BackgroundTasks/ReminderNotifications.swift
+++ b/MobileWallet/Common/BackgroundTasks/ReminderNotifications.swift
@@ -65,7 +65,7 @@ class ReminderNotifications {
             identifier: "scheduled-reminders-recipient-1",
             title: ReminderNotifications.titleString,
             body: NSLocalizedString("Open Tari Aurora", comment: "Local reminder notifications"),
-            deliverAfter: 60 * 60 * 24
+            deliverAfter: TariSettings.shared.environment == .production ? 60 * 60 * 24 : 60 * 60 * 2 //24h for prod and 2h for debug/testflight
         ),
         ScheduledReminder(
             identifier: "scheduled-reminders-recipient-2",
@@ -77,7 +77,7 @@ class ReminderNotifications {
                 ),
                 TariSettings.shared.network.currencyDisplayTicker
             ),
-            deliverAfter: 60 * 60 * 48
+            deliverAfter: TariSettings.shared.environment == .production ? 60 * 60 * 48 : 60 * 60 * 4 //48h for prod and 4h for debug/testflight
         )
     ]
 

--- a/MobileWallet/Common/BackgroundTasks/ScheduleReminderNotificationsOperation.swift
+++ b/MobileWallet/Common/BackgroundTasks/ScheduleReminderNotificationsOperation.swift
@@ -54,7 +54,6 @@ class ScheduleReminderNotificationsOperation: Operation {
             return
         }
 
-        //Any feature background logic here
         NotificationManager.shared.cancelAllFutureReminderNotifications()
 
         guard let firstReminder = ReminderNotifications.recipientReminderNotifications.first else {

--- a/MobileWallet/Common/NotificationManager.swift
+++ b/MobileWallet/Common/NotificationManager.swift
@@ -46,6 +46,7 @@ private struct TokenRegistrationServerRequest: Codable {
     let platform: String = "ios"
     let signature: String
     let public_nonce: String
+    let sandbox = TariSettings.shared.environment == .debug
 }
 
 private struct SendNotificationServerRequest: Codable {
@@ -162,9 +163,6 @@ class NotificationManager {
 
     /// After syncing with base node we can cancel all prreviosuly scheduled reminder notifications that were going to remind the user to open up the app
     func cancelAllFutureReminderNotifications() {
-        // TODO remove below
-        return
-
         ReminderNotifications.shared.shouldScheduleRemindersUpdatedAt = nil
 
         var identifiers: [String] = []

--- a/MobileWallet/Info.plist
+++ b/MobileWallet/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>95</string>
+	<string>98</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/MobileWallet/TariLib/Wrappers/Utils/TariSettings.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/TariSettings.swift
@@ -114,19 +114,19 @@ struct TariSettings {
     func getRandomBaseNode() -> String {
         return defaultBaseNodePool[Int.random(in: 0 ... (defaultBaseNodePool.count-1))]
     }
+    
+    let pushNotificationServer = "https://push.tari.com"
 
     #if DEBUG
     let torEnabled = true //If just working on UI updates, this can be made false
     //Used for showing a little extra detail in the UI to help debugging
     private let isDebug = true
     let maxMbLogsStorage: UInt64 = 5000 //5GB
-    let pushNotificationServer = "https://9e69320ddd75.ngrok.io" // "https://push.tari.com"
     let expirePendingTransactionsAfter: TimeInterval = 60 * 60 * 24 * 1 //1 day
     #else
     let torEnabled = true
     private let isDebug = false
     let maxMbLogsStorage: UInt64 = 500 //500MB
-    let pushNotificationServer = "https://push.tari.com"
     let expirePendingTransactionsAfter: TimeInterval = 60 * 60 * 24 * 3 //3 days
     #endif
 

--- a/MobileWalletNotificationService/Info.plist
+++ b/MobileWalletNotificationService/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>95</string>
+	<string>98</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/MobileWalletTests/Info.plist
+++ b/MobileWalletTests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>95</string>
+	<string>98</string>
 </dict>
 </plist>

--- a/MobileWalletUISnapshots/Info.plist
+++ b/MobileWalletUISnapshots/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>95</string>
+	<string>98</string>
 </dict>
 </plist>

--- a/MobileWalletUITests/Info.plist
+++ b/MobileWalletUITests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>95</string>
+	<string>98</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Less time before reminders are sent in testflight/debug.  (2h and 4h instead of 24h and 48h)
- Registering token for sandbox mode in debug.
- Cancelling local reminders was accidentally switched off

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
