### PR TITLE
Wait for wallet to restart instead of showing user errors

### DIFF
--- a/MobileWallet/Screens/Home/HomeViewController.swift
+++ b/MobileWallet/Screens/Home/HomeViewController.swift
@@ -237,10 +237,11 @@ class HomeViewController: UIViewController {
 
     private func refreshBalance() {
         guard let wallet = TariLib.shared.tariWallet else {
-            UserFeedback.shared.error(
-                title: NSLocalizedString("wallet.error.title", comment: "Wallet error"),
-                description: NSLocalizedString("wallet.error.wallet_not_initialized", comment: "Wallet error")
-            )
+            TariLib.shared.waitIfWalletIsRestarting { [weak self] (success) in
+                if success == true {
+                    self?.refreshBalance()
+                }
+            }
             return
         }
 

--- a/MobileWallet/Screens/Home/TransactionHistory/TransactionsTableViewController.swift
+++ b/MobileWallet/Screens/Home/TransactionHistory/TransactionsTableViewController.swift
@@ -219,10 +219,11 @@ class TransactionsTableViewController: UITableViewController {
 
     private func refreshTable() {
         guard let wallet = TariLib.shared.tariWallet else {
-            UserFeedback.shared.error(
-                title: NSLocalizedString("wallet.error.failed_to_access", comment: "Wallet error"),
-                description: ""
-            )
+            TariLib.shared.waitIfWalletIsRestarting { [weak self] (success) in
+                if success == true {
+                    self?.refreshTable()
+                }
+            }
             return
         }
 

--- a/MobileWallet/Screens/Profile/ProfileViewController.swift
+++ b/MobileWallet/Screens/Profile/ProfileViewController.swift
@@ -203,6 +203,15 @@ class ProfileViewController: UIViewController {
     }
 
     private func generateQRCode() {
+        guard let _ = TariLib.shared.tariWallet else {
+            TariLib.shared.waitIfWalletIsRestarting { [weak self] (success) in
+                if success == true {
+                    self?.generateQRCode()
+                }
+            }
+            return
+        }
+
         do {
             try genQRCode()
         } catch {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Users are shown errors when backgrounding and foregrounding the app again and wallet services are used before the wallet has restarted. This fix waits for the wallet to restart before attempting again.

## Motivation and Context
<!--- What feature is it related to? Why is this change required? What problem does it solve?-->
<!--- If it fixes an open issue or closes a feature ticket, please link to the issue here. -->
Related to https://github.com/tari-project/wallet-ios/issues/459

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
