### PR TITLE
Backup prompt logic tweak

### DIFF
--- a/MobileWallet/Backup/BackupPrompts.swift
+++ b/MobileWallet/Backup/BackupPrompts.swift
@@ -57,7 +57,7 @@ private class BackupPrompts {
         let cancelButton: String
     }
 
-    enum PromptTypes: CaseIterable {
+    enum PromptType: CaseIterable {
         case first
         case second
         case third
@@ -138,7 +138,7 @@ private class BackupPrompts {
             return
         }
 
-        for type in PromptTypes.allCases {
+        for type in PromptType.allCases.reversed() {
             //If they have been shown this once, skip over this prompt
             guard UserDefaults.standard.bool(forKey: type.userDefaultsKey) == false else {
                 continue
@@ -163,7 +163,7 @@ private class BackupPrompts {
                 continue
             }
 
-            UserDefaults.standard.set(true, forKey: type.userDefaultsKey)
+            setAsShown(type)
             let content = type.content
             UserFeedback.shared.callToAction(
                 title: content.title,
@@ -184,10 +184,23 @@ private class BackupPrompts {
         }
     }
 
+    /// Sets all triggers as "shown" if it matches the passed trigger and/or is below the passed trigger. i.e. The second tigger will set the first and second as shown.
+    /// - Parameter type: Prompt type (first, second, third)
+    private func setAsShown(_ type: PromptType) {
+        var setAsShown: Bool = false
+        for t in PromptType.allCases.reversed() {
+            if t == type {
+                setAsShown = true
+            }
+
+            UserDefaults.standard.set(setAsShown, forKey: t.userDefaultsKey)
+        }
+    }
+
     /// For testing in debug only
     func resetTriggers() {
         guard TariSettings.shared.environment == .debug else {  return }
-        for type in PromptTypes.allCases {
+        for type in PromptType.allCases {
             UserDefaults.standard.set(false, forKey: type.userDefaultsKey)
         }
     }
@@ -195,6 +208,7 @@ private class BackupPrompts {
 
 extension UIViewController {
     func checkBackupPrompt(delay: TimeInterval) {
+//        return BackupPrompts.shared.resetTriggers()
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self = self else { return }
             BackupPrompts.shared.check(self)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We have 3 backup prompt triggers. Previously if you jumped straight to meeting the requirements for prompt 2, then you would also meet the requirements for prompt 1 and the app would first show you prompt 1. With this change if you meet the requirements for prompt 1 and 2 then you will only be shown prompt 2.

## Motivation and Context
<!--- What feature is it related to? Why is this change required? What problem does it solve?-->
<!--- If it fixes an open issue or closes a feature ticket, please link to the issue here. -->
Related to https://github.com/tari-project/wallet-ios/issues/497

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
