### PR TITLE
Backup upload timeout period and Rincewind display name change.

### DIFF
--- a/MobileWallet/Screens/AppEntry/Splash/SplashViewControllerSetup.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/SplashViewControllerSetup.swift
@@ -245,8 +245,9 @@ extension SplashViewController {
     func setupContraintsVersionLabel() {
         versionLabel.font = Theme.shared.fonts.splashVersionFooterLabel
         versionLabel.textColor = Theme.shared.colors.splashVersionLabel
-        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String, let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
-            versionLabel.text = "\(TariSettings.shared.network.networkDisplayName) V\(version) (\(build))".uppercased()
+        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+            let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+            versionLabel.text = "\(TariSettings.shared.network.networkDisplayName.uppercased()) v\(version) (\(build))"
         }
 
         view.addSubview(versionLabel)
@@ -254,12 +255,14 @@ extension SplashViewController {
         versionLabel.numberOfLines = 0
         versionLabel.translatesAutoresizingMaskIntoConstraints = false
 
-        versionLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8).isActive = true
+        versionLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                                             constant: -12).isActive = true
         versionLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor,
-                                               constant: Theme.shared.sizes.appSidePadding).isActive = true
+                                              constant: Theme.shared.sizes.appSidePadding).isActive = true
         versionLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor,
-                                                constant: -Theme.shared.sizes.appSidePadding).isActive = true
-        versionLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: 0).isActive = true
+                                               constant: -Theme.shared.sizes.appSidePadding).isActive = true
+        versionLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor,
+                                              constant: 0).isActive = true
     }
 
     func titleAnimation() {

--- a/MobileWallet/Screens/Settings/BackUpSettings/BackupWalletSettingsViewController.swift
+++ b/MobileWallet/Screens/Settings/BackUpSettings/BackupWalletSettingsViewController.swift
@@ -318,19 +318,19 @@ extension BackupWalletSettingsViewController: UITableViewDelegate, UITableViewDa
         label.leadingAnchor.constraint(equalTo: header.leadingAnchor, constant: 25).isActive = true
         label.topAnchor.constraint(equalTo: header.topAnchor, constant: 30).isActive = true
 
-        let desctiptionLabel = UILabel()
-        desctiptionLabel.numberOfLines = 0
-        desctiptionLabel.font = Theme.shared.fonts.settingsSeedPhraseDescription
-        desctiptionLabel.textColor = Theme.shared.colors.settingsViewDescription
-        desctiptionLabel.text = NSLocalizedString("backup_wallet_settings.header.description", comment: "BackupWalletSettings view")
+        let descriptionLabel = UILabel()
+        descriptionLabel.numberOfLines = 0
+        descriptionLabel.font = Theme.shared.fonts.settingsSeedPhraseDescription
+        descriptionLabel.textColor = Theme.shared.colors.settingsViewDescription
+        descriptionLabel.text = NSLocalizedString("backup_wallet_settings.header.description", comment: "BackupWalletSettings view")
 
-        header.addSubview(desctiptionLabel)
+        header.addSubview(descriptionLabel)
 
-        desctiptionLabel.translatesAutoresizingMaskIntoConstraints = false
-        desctiptionLabel.topAnchor.constraint(equalTo: label.bottomAnchor, constant: 25).isActive = true
-        desctiptionLabel.leadingAnchor.constraint(equalTo: header.leadingAnchor, constant: 25).isActive = true
-        desctiptionLabel.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -25).isActive = true
-        desctiptionLabel.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -25).isActive = true
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        descriptionLabel.topAnchor.constraint(equalTo: label.bottomAnchor, constant: 15).isActive = true
+        descriptionLabel.leadingAnchor.constraint(equalTo: header.leadingAnchor, constant: 25).isActive = true
+        descriptionLabel.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -25).isActive = true
+        descriptionLabel.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -25).isActive = true
 
         return header
     }

--- a/MobileWallet/TariLib/Wrappers/Utils/TariSettings.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/TariSettings.swift
@@ -56,7 +56,7 @@ enum TariNetwork: String {
     var networkDisplayName: String {
         switch self {
         case .rincewind:
-            return "rincewind"
+            return "testnet"
         default:
             return "mainnet"
         }


### PR DESCRIPTION
Reduces the upload backup timeout period to 20 secs. Changes Rincewind network display name to Testnet.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Reduced backup upload timeout period to 20secs from 30 secs. Backup size is usually around some 10 Kbytes, and if everything is ok it usually takes around 4-5 second to upload.

Changed Rincewind display name to Testnet to match with Android.

## How Has This Been Tested?
Tested on device (13.6) and emulator (13.1).

## Screenshots and/or video clip
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
