### PR TITLE
autobackup hotfix

### DIFF
--- a/MobileWallet/Backup/ICloudBackup.swift
+++ b/MobileWallet/Backup/ICloudBackup.swift
@@ -114,7 +114,8 @@ extension ICloudBackupError: LocalizedError {
 }
 
 protocol ICloudBackupObserver: AnyObject {
-    func onUploadProgress(percent: Double, started: Bool, completed: Bool, error: Error?)
+    func onUploadProgress(percent: Double, started: Bool, completed: Bool)
+    func failedToCreateBackup(error: Error)
 }
 
 class ICloudBackup: NSObject {
@@ -393,13 +394,26 @@ extension ICloudBackup {
             guard let self = self else { return }
             self.observers.allObjects.forEach {
                 if let object = $0 as? ICloudBackupObserver {
-                    object.onUploadProgress(percent: percent, started: started, completed: completed, error: error)
+                    object.onUploadProgress(percent: percent, started: started, completed: completed)
+                    if error != nil {
+                        object.failedToCreateBackup(error: error!)
+                        self.showError(error: error!)
+                    }
                 }
                 if completed {
                     self.endBackgroundBackupTask()
                 }
             }
         }
+    }
+
+    private func showError(error: Error) {
+        var title = NSLocalizedString("iCloud_backup.error.title.create_backup", comment: "iCloudBackup error")
+
+        if let localizedError = error as? LocalizedError, localizedError.failureReason != nil {
+           title = localizedError.failureReason!
+        }
+        UserFeedback.shared.error(title: title, description: error.localizedDescription, error: nil)
     }
 }
 

--- a/MobileWallet/Screens/Home/TransactionHistory/TransactionsTableViewController.swift
+++ b/MobileWallet/Screens/Home/TransactionHistory/TransactionsTableViewController.swift
@@ -372,10 +372,14 @@ class TransactionsTableViewController: UITableViewController {
 }
 
 extension TransactionsTableViewController: ICloudBackupObserver {
-    func onUploadProgress(percent: Double, started: Bool, completed: Bool, error: Error?) {
+    func onUploadProgress(percent: Double, started: Bool, completed: Bool) {
         if started || completed {
             updateRefreshView()
         }
+    }
+
+    func failedToCreateBackup(error: Error) {
+        updateRefreshView()
     }
 
     private func observeBackupState() {

--- a/MobileWallet/Screens/Settings/BackUpSettings/BackupWalletSettingsViewController.swift
+++ b/MobileWallet/Screens/Settings/BackUpSettings/BackupWalletSettingsViewController.swift
@@ -196,8 +196,8 @@ class BackupWalletSettingsViewController: SettingsParentTableViewController {
         }
     }
 
-    override func onUploadProgress(percent: Double, started: Bool, completed: Bool, error: Error?) {
-        super.onUploadProgress(percent: percent, started: started, completed: completed, error: error)
+    override func onUploadProgress(percent: Double, started: Bool, completed: Bool) {
+        super.onUploadProgress(percent: percent, started: started, completed: completed)
         if completed { backupSender = .none }
     }
 

--- a/MobileWallet/Screens/Settings/SettingsParentTableViewController.swift
+++ b/MobileWallet/Screens/Settings/SettingsParentTableViewController.swift
@@ -85,8 +85,8 @@ class SettingsParentTableViewController: SettingsParentViewController {
 }
 
 extension SettingsParentTableViewController {
-    override func onUploadProgress(percent: Double, started: Bool, completed: Bool, error: Error?) {
-        super.onUploadProgress(percent: percent, started: started, completed: completed, error: error)
+    override func onUploadProgress(percent: Double, started: Bool, completed: Bool) {
+        super.onUploadProgress(percent: percent, started: started, completed: completed)
         updateMarks()
         if completed || started {
             reloadTableViewWithAnimation()

--- a/MobileWallet/Screens/Settings/SettingsParentViewController.swift
+++ b/MobileWallet/Screens/Settings/SettingsParentViewController.swift
@@ -54,22 +54,15 @@ class SettingsParentViewController: UIViewController {
         styleNavigatorBar(isHidden: true)
         setupViews()
     }
-
-    @objc func failedToCreateBackup(error: Error) {
-        var title = NSLocalizedString("iCloud_backup.error.title.create_backup", comment: "iCloudBackup error")
-
-        if let localizedError = error as? LocalizedError, localizedError.failureReason != nil {
-           title = localizedError.failureReason!
-        }
-        UserFeedback.shared.error(title: title, description: error.localizedDescription, error: nil)
-    }
 }
 
 extension SettingsParentViewController: ICloudBackupObserver {
-    @objc func onUploadProgress(percent: Double, started: Bool, completed: Bool, error: Error?) {
-        if error != nil {
-            failedToCreateBackup(error: error!)
-        }
+    @objc func onUploadProgress(percent: Double, started: Bool, completed: Bool) {
+
+    }
+
+    @objc func failedToCreateBackup(error: Error) {
+
     }
 }
 

--- a/MobileWallet/TariLib/Wrappers/Wallet.swift
+++ b/MobileWallet/TariLib/Wrappers/Wallet.swift
@@ -205,12 +205,12 @@ class Wallet {
 
         let directSendResultCallback: (@convention(c) (UInt64, Bool) -> Void)? = { txID, success in
             TariEventBus.postToMainThread(.directSend, sender: CallbackTxResult(id: txID, success: success))
-            TariEventBus.postToMainThread(.requiresBackup)
             let message = "Direct send lib callback. txID=\(txID)"
             if success {
                 TariLogger.verbose("\(message) ✅")
                 TariEventBus.postToMainThread(.transactionListUpdate)
                 TariEventBus.postToMainThread(.balanceUpdate)
+                TariEventBus.postToMainThread(.requiresBackup)
             } else {
                 TariLogger.error("\(message) failure")
             }
@@ -218,12 +218,12 @@ class Wallet {
 
         let storeAndForwardSendResultCallback: (@convention(c) (UInt64, Bool) -> Void)? = { txID, success in
             TariEventBus.postToMainThread(.storeAndForwardSend, sender: CallbackTxResult(id: txID, success: success))
-            TariEventBus.postToMainThread(.requiresBackup)
             let message = "Store and forward lib callback. txID=\(txID)"
             if success {
                 TariLogger.verbose("\(message) ✅")
                 TariEventBus.postToMainThread(.transactionListUpdate)
                 TariEventBus.postToMainThread(.balanceUpdate)
+                TariEventBus.postToMainThread(.requiresBackup)
             } else {
                 TariLogger.error("\(message) failure")
             }


### PR DESCRIPTION


## Description
fixed: "modal window with backup fail message shows only on settings screen"
removed triggering a backup when direct/s&f send fails

## How Has This Been Tested?
manually, run tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
