### PR TITLE
Including missing cancelled transactions in new full list

### DIFF
--- a/MobileWallet/Screens/Home/TransactionHistory/TransactionTableViewModel.swift
+++ b/MobileWallet/Screens/Home/TransactionHistory/TransactionTableViewModel.swift
@@ -143,14 +143,6 @@ class TransactionTableViewModel: NSObject {
 
         var statusMessage = ""
 
-        //Cancelled tranaction
-        if let compledTx = tx as? CompletedTransaction {
-            if compledTx.isCancelled {
-                isCancelled = true
-                statusMessage = "Transaction Cancelled"
-            }
-        }
-
         switch tx.status.0 {
         case .pending:
             if tx.direction == .inbound {
@@ -162,6 +154,14 @@ class TransactionTableViewModel: NSObject {
             statusMessage = NSLocalizedString("refresh_view.final_processing", comment: "Refresh view")
         default:
             statusMessage = ""
+        }
+
+        //Cancelled tranaction
+        if let compledTx = tx as? CompletedTransaction {
+            if compledTx.isCancelled {
+                isCancelled = true
+                statusMessage = NSLocalizedString("transaction_detail.payment_cancelled", comment: "Transaction detail view")
+            }
         }
 
         if statusMessage.isEmpty {

--- a/MobileWalletTests/TariLibWrapperTests.swift
+++ b/MobileWalletTests/TariLibWrapperTests.swift
@@ -253,18 +253,28 @@ class TariLibWrapperTests: XCTestCase {
         XCTAssertGreaterThan(pendingIncomingBalance, 0)
         XCTAssertGreaterThan(pendingOutgoingBalance, 0)
     
-        let (groupedTransactions, groupedTransactionsError) = wallet.groupedCompletedAndCancelledTransactions
-        guard groupedTransactionsError == nil else {
-            XCTFail("Failed to load grouped transactions: /(groupedTransactionsError!.localizedDescription)")
+        let (allTransactions, allTransactionsError) = wallet.allTransactions
+        guard allTransactionsError == nil else {
+            XCTFail("Failed to load all transactions: \(allTransactionsError!.localizedDescription)")
             return
         }
-                    
-        XCTAssertGreaterThan(groupedTransactions.count, 0)
-        XCTAssertGreaterThan(groupedTransactions[0].count, 0)
+        
+        let totalTransactionsBeforeCancelling = allTransactions.count
+        
+        XCTAssertEqual(totalTransactionsBeforeCancelling, 16)
         
         //Test cancel function when a pending tx has aged for 2 seconds
         sleep(2)
         XCTAssertNoThrow(try wallet.cancelExpiredPendingTransactions(after: 1))
+        
+        let (allTransactionsWithCancelled, allTransactionsWithCancelledError) = wallet.allTransactions
+        guard allTransactionsWithCancelledError == nil else {
+            XCTFail("Failed to load all (including cancelled) transactions: \(allTransactionsWithCancelledError!.localizedDescription)")
+            return
+        }
+        
+        //Cancelled transactions are still in the list
+        XCTAssertEqual(allTransactionsWithCancelled.count, totalTransactionsBeforeCancelling)
     }
     
     func testBackupAndRestoreWallet() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes a bug introduced causing cancelled transactions to be left out when the transaction feed was changed to be not be grouped anymore.

## Motivation and Context
<!--- What feature is it related to? Why is this change required? What problem does it solve?-->
<!--- If it fixes an open issue or closes a feature ticket, please link to the issue here. -->
Related to https://github.com/tari-project/wallet-ios/issues/558

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and adjusted unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
