### PR TITLE
Add note emoji id Giphy VC fix, refactoring, add amount tx fee show/hide improvement

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -547,9 +547,9 @@
 		BF8316FD23EF7EAA00235403 /* LAContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8316FC23EF7EAA00235403 /* LAContext.swift */; };
 		BF8316FE23EF7EAA00235403 /* LAContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8316FC23EF7EAA00235403 /* LAContext.swift */; };
 		BF8316FF23EF7EAA00235403 /* LAContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8316FC23EF7EAA00235403 /* LAContext.swift */; };
-		BFAB5D1123FDEA69009E8563 /* EmoticonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAB5D1023FDEA69009E8563 /* EmoticonView.swift */; };
-		BFAB5D1223FDEA6A009E8563 /* EmoticonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAB5D1023FDEA69009E8563 /* EmoticonView.swift */; };
-		BFAB5D1323FDEA6A009E8563 /* EmoticonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAB5D1023FDEA69009E8563 /* EmoticonView.swift */; };
+		BFAB5D1123FDEA69009E8563 /* EmojiIdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAB5D1023FDEA69009E8563 /* EmojiIdView.swift */; };
+		BFAB5D1223FDEA6A009E8563 /* EmojiIdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAB5D1023FDEA69009E8563 /* EmojiIdView.swift */; };
+		BFAB5D1323FDEA6A009E8563 /* EmojiIdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAB5D1023FDEA69009E8563 /* EmojiIdView.swift */; };
 		BFC5532523D9B8E4009130A8 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC5532423D9B8E4009130A8 /* UIView.swift */; };
 		BFC5532623D9B8E4009130A8 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC5532423D9B8E4009130A8 /* UIView.swift */; };
 		BFC5532723D9B8E4009130A8 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC5532423D9B8E4009130A8 /* UIView.swift */; };
@@ -829,7 +829,7 @@
 		BF191A3123E70D3200D33C85 /* NerdEmojiAnimation.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = NerdEmojiAnimation.json; sourceTree = "<group>"; };
 		BF5537B82412B9BB0071328C /* purple_orb.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = purple_orb.mp4; sourceTree = "<group>"; };
 		BF8316FC23EF7EAA00235403 /* LAContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LAContext.swift; sourceTree = "<group>"; };
-		BFAB5D1023FDEA69009E8563 /* EmoticonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmoticonView.swift; sourceTree = "<group>"; };
+		BFAB5D1023FDEA69009E8563 /* EmojiIdView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiIdView.swift; sourceTree = "<group>"; };
 		BFC5532423D9B8E4009130A8 /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
 		BFD758E523E98ABD00B0F1A5 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		BFE1FBFF23E20E3600BA5EEC /* WalletCreationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCreationViewController.swift; sourceTree = "<group>"; };
@@ -1190,7 +1190,7 @@
 				37ABB69324781F8600F08163 /* UILabelWithPadding.swift */,
 				00325EC9239E4A1000F76918 /* FadedOverlayView.swift */,
 				49996E1823F164BA002B6696 /* AnimatedBalanceLabel.swift */,
-				BFAB5D1023FDEA69009E8563 /* EmoticonView.swift */,
+				BFAB5D1023FDEA69009E8563 /* EmojiIdView.swift */,
 				00D988682449B04B000FDC9C /* AnimatedRefreshingView.swift */,
 				379D27AE244EF25000F1AD98 /* NavigationBarWithSubtitle.swift */,
 				375DB1DF246E90D100B2BEF4 /* NavigationBar.swift */,
@@ -2286,7 +2286,7 @@
 				37ABB69024781CE800F08163 /* UILabel.swift in Sources */,
 				379D27AF244EF25000F1AD98 /* NavigationBarWithSubtitle.swift in Sources */,
 				376C62AE247574850091BB28 /* Animation+EnumInit.swift in Sources */,
-				BFAB5D1123FDEA69009E8563 /* EmoticonView.swift in Sources */,
+				BFAB5D1123FDEA69009E8563 /* EmojiIdView.swift in Sources */,
 				37AFE265245193CA006EA270 /* AlwaysPoppableNavigationController.swift in Sources */,
 				37BB696B245705D20013AC4D /* RadialGradientView.swift in Sources */,
 				004277FB23E1A61F00AE7BD9 /* ErrorDescriptions.swift in Sources */,
@@ -2398,7 +2398,7 @@
 				37AFE266245193CA006EA270 /* AlwaysPoppableNavigationController.swift in Sources */,
 				3723A7A224AB57F4003382EB /* AESEncryptionTests.swift in Sources */,
 				491AB89A23F1B36000372189 /* AnimatedBalanceLabel.swift in Sources */,
-				BFAB5D1223FDEA6A009E8563 /* EmoticonView.swift in Sources */,
+				BFAB5D1223FDEA6A009E8563 /* EmojiIdView.swift in Sources */,
 				00BCE480240D5A9700B181F3 /* OnionManager.swift in Sources */,
 				00E2BCAA236AB28200C2A105 /* TransactionTableViewCell.swift in Sources */,
 				0087A1AA23F4235400B89EE7 /* ScanViewController.swift in Sources */,
@@ -2482,7 +2482,7 @@
 				37765D2824A35BA20091AE2A /* AESEncryption.swift in Sources */,
 				37875E4624D85C4300C0595B /* LoadingGIFButton.swift in Sources */,
 				491AB8A223F3FF4400372189 /* AddAmountViewController.swift in Sources */,
-				BFAB5D1323FDEA6A009E8563 /* EmoticonView.swift in Sources */,
+				BFAB5D1323FDEA6A009E8563 /* EmojiIdView.swift in Sources */,
 				37B48A8124B3312000F8A8D2 /* PasswordVerificationViewController.swift in Sources */,
 				37EE285C2485649800335EDC /* WordsFlexView.swift in Sources */,
 				BFF1ED9F2408111000CC9EF6 /* SendingTariViewController.swift in Sources */,

--- a/MobileWallet/Common/Extensions/UIViewController.swift
+++ b/MobileWallet/Common/Extensions/UIViewController.swift
@@ -40,8 +40,6 @@
 
 import UIKit
 
-var navBarEmojis: EmoticonView?
-
 var hasNotch: Bool {
     let bottom = UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0
     return bottom > 0

--- a/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
@@ -70,7 +70,7 @@ class WalletCreationViewController: UIViewController {
     private var animationViewHeightConstraint: NSLayoutConstraint?
     private var animationViewWidthConstraint: NSLayoutConstraint?
 
-    private let userEmojiContainer = EmoticonView()
+    private let emojiIdView = EmojiIdView()
     private let tapToSeeButtonContainer = UIView()
 
     private let firstLabel = TransitionLabel()
@@ -125,19 +125,19 @@ class WalletCreationViewController: UIViewController {
             self.thirdLabel.alpha = 0.0
             self.animationView.alpha = 0.0
             self.numpadImageView.alpha = 0.0
-            self.userEmojiContainer.alpha = 0.0
+            self.emojiIdView.alpha = 0.0
             self.tapToSeeButtonContainer.alpha = 0.0
             self.view.layoutIfNeeded()}, completion: {
                 [weak self] _ in
                 guard let self = self else { return }
                 self.animationView.stop()
-                self.stackView.setCustomSpacing(0, after: self.userEmojiContainer)
+                self.stackView.setCustomSpacing(0, after: self.emojiIdView)
                 self.stackView.setCustomSpacing(0, after: self.secondLabel)
                 self.stackView.setCustomSpacing(0, after: self.animationView)
                 self.stackViewCenterYConstraint?.constant = 0.0
 
                 self.numpadImageView.isHidden = true
-                self.userEmojiContainer.isHidden = true
+                self.emojiIdView.isHidden = true
 
                 completion?()
         })
@@ -176,7 +176,7 @@ class WalletCreationViewController: UIViewController {
     }
 
     @objc public func tapToSeeButtonAction(_ sender: UIButton) {
-        userEmojiContainer.expand()
+        emojiIdView.expand()
         tapToExpandAction()
     }
 
@@ -200,7 +200,7 @@ class WalletCreationViewController: UIViewController {
             }
         case .showEmojiId:
             hideSubviews { [weak self] in
-                self?.userEmojiContainer.shrink(animated: false)
+                self?.emojiIdView.shrink(animated: false)
                 self?.prepareSubviews(for: .localAuthentication)
                 self?.showLocalAuthentication()
             }
@@ -296,12 +296,12 @@ extension WalletCreationViewController {
     // MARK: - Show Emoji ID
     private func showYourEmoji() {
         secondLabel.showLabel(duration: 1.0)
-        userEmojiContainer.isHidden = false
+        emojiIdView.isHidden = false
         view.layoutIfNeeded()
-        userEmojiContainer.expand(animated: false)
-        userEmojiContainer.alpha = 0
+        emojiIdView.expand(animated: false)
+        emojiIdView.alpha = 0
 
-        self.userEmojiContainer.tapToExpand = { [weak self] expanded in
+        self.emojiIdView.tapToExpand = { [weak self] expanded in
             if self?.state == .showEmojiId {
                 self?.showContinueButton()
                 UIView.animate(withDuration: CATransaction.animationDuration()) { [weak self] in
@@ -312,10 +312,10 @@ extension WalletCreationViewController {
 
         UIView.animate(withDuration: 1, animations: { [weak self] in
             self?.thirdLabel.alpha = 1.0
-            self?.userEmojiContainer.alpha = 1.0
+            self?.emojiIdView.alpha = 1.0
         }) { [weak self] (_) in
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self?.userEmojiContainer.shrink(completion: { [weak self] in
+                self?.emojiIdView.shrink(completion: { [weak self] in
                     self?.tapToSeeButtonContainer.alpha = 1.0
                 })
             }
@@ -429,7 +429,7 @@ extension WalletCreationViewController {
         continueButton.setTitle(NSLocalizedString("common.continue", comment: "Common"), for: .normal)
 
         if let pubKey = TariLib.shared.tariWallet?.publicKey.0 {
-            userEmojiContainer.setupView(
+            emojiIdView.setupView(
                 pubKey: pubKey,
                 textCentered: true,
                 inViewController: self,
@@ -437,7 +437,7 @@ extension WalletCreationViewController {
             )
         }
 
-        stackView.setCustomSpacing(30, after: userEmojiContainer)
+        stackView.setCustomSpacing(30, after: emojiIdView)
     }
 
     private func prepareForLocalAuthentication() {
@@ -527,12 +527,12 @@ extension WalletCreationViewController {
     }
 
     private func setupUserEmojiContainer() {
-        userEmojiContainer.alpha = 0.0
-        userEmojiContainer.isHidden = true
-        stackView.addArrangedSubview(userEmojiContainer)
-        stackView.setCustomSpacing(30, after: userEmojiContainer)
-        userEmojiContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: 60).isActive = true
-        userEmojiContainer.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+        emojiIdView.alpha = 0.0
+        emojiIdView.isHidden = true
+        stackView.addArrangedSubview(emojiIdView)
+        stackView.setCustomSpacing(30, after: emojiIdView)
+        emojiIdView.heightAnchor.constraint(greaterThanOrEqualToConstant: 60).isActive = true
+        emojiIdView.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
     }
 
     private func setupAnimationView() {
@@ -658,7 +658,7 @@ extension WalletCreationViewController {
         view.addSubview(tapToSeeButtonContainer)
 
         tapToSeeButtonContainer.translatesAutoresizingMaskIntoConstraints = false
-        tapToSeeButtonContainer.bottomAnchor.constraint(equalTo: userEmojiContainer.topAnchor, constant: 3).isActive = true
+        tapToSeeButtonContainer.bottomAnchor.constraint(equalTo: emojiIdView.topAnchor, constant: 3).isActive = true
         tapToSeeButtonContainer.widthAnchor.constraint(equalToConstant: 159).isActive = true
         tapToSeeButtonContainer.heightAnchor.constraint(equalToConstant: 38).isActive = true
         tapToSeeButtonContainer.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: 0).isActive = true

--- a/MobileWallet/Screens/Home/Transaction/TransactionViewController.swift
+++ b/MobileWallet/Screens/Home/Transaction/TransactionViewController.swift
@@ -58,7 +58,7 @@ class TransactionViewController: UIViewController {
     var valueContainerViewHeightAnchor = NSLayoutConstraint()
     var valueCenterYAnchorConstraint = NSLayoutConstraint()
     let valueLabel = UILabel()
-    let emojiButton = EmoticonView()
+    let emojiIdView = EmojiIdView()
     let fromContainerView = UIView()
     let fromHeadingLabel = UILabel()
     let contactNameContainer = UIView()
@@ -432,12 +432,12 @@ class TransactionViewController: UIViewController {
             }
 
             if let pubKey = contactPublicKey {
-                emojiButton.setupView(
+                emojiIdView.setupView(
                     pubKey: pubKey,
                     textCentered: false,
                     inViewController: self
                 )
-                emojiButton.blackoutParent = view
+                emojiIdView.blackoutParent = view
             }
 
             let (date, dateError) = tx.date

--- a/MobileWallet/Screens/Home/Transaction/TransactionViewControllerExtension.swift
+++ b/MobileWallet/Screens/Home/Transaction/TransactionViewControllerExtension.swift
@@ -127,23 +127,23 @@ extension TransactionViewController {
         fromHeadingLabel.topAnchor.constraint(equalTo: fromContainerView.topAnchor, constant: 20).isActive = true
         fromHeadingLabel.leadingAnchor.constraint(equalTo: fromContainerView.leadingAnchor, constant: Theme.shared.sizes.appSidePadding).isActive = true
 
-        emojiButton.translatesAutoresizingMaskIntoConstraints = false
-        fromContainerView.addSubview(emojiButton)
-        emojiButton.bottomAnchor.constraint(equalTo: fromContainerView.bottomAnchor, constant: -16).isActive = true
-        emojiButton.leadingAnchor.constraint(
+        emojiIdView.translatesAutoresizingMaskIntoConstraints = false
+        fromContainerView.addSubview(emojiIdView)
+        emojiIdView.bottomAnchor.constraint(equalTo: fromContainerView.bottomAnchor, constant: -16).isActive = true
+        emojiIdView.leadingAnchor.constraint(
             equalTo: fromContainerView.leadingAnchor,
             constant: Theme.shared.sizes.appSidePadding
         ).isActive = true
-        emojiButton.trailingAnchor.constraint(
+        emojiIdView.trailingAnchor.constraint(
             equalTo: fromContainerView.trailingAnchor,
             constant: -Theme.shared.sizes.appSidePadding
         ).isActive = true
-        emojiButton.cornerRadius = 12.0
+        emojiIdView.cornerRadius = 12.0
     }
 
     func setupAddContactButton() {
         addContactButton.translatesAutoresizingMaskIntoConstraints = false
-        fromContainerView.insertSubview(addContactButton, belowSubview: emojiButton)
+        fromContainerView.insertSubview(addContactButton, belowSubview: emojiIdView)
         addContactButton.topAnchor.constraint(equalTo: fromHeadingLabel.bottomAnchor, constant: bottomHeadingPadding).isActive = true
         addContactButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Theme.shared.sizes.appSidePadding).isActive = true
         addContactButton.setTitle(NSLocalizedString("transaction_detail.add_contact_name", comment: "Transaction detail view"), for: .normal)

--- a/MobileWallet/Screens/Profile/ProfileViewController.swift
+++ b/MobileWallet/Screens/Profile/ProfileViewController.swift
@@ -42,7 +42,7 @@ import UIKit
 
 class ProfileViewController: UIViewController {
 
-    let emojiView = EmoticonView()
+    let emojiIdView = EmojiIdView()
     let middleLabel = UILabel()
     let bottomView = UIView()
     let qrContainer = UIView()
@@ -54,14 +54,14 @@ class ProfileViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationBar()
-        setupEmojiView()
+        setupEmojiIdView()
         setupMiddleLabel()
         setupQRContainer()
         setupQRImageView()
         generateQRCode()
         customizeViews()
 
-        view.bringSubviewToFront(emojiView)
+        view.bringSubviewToFront(emojiIdView)
 
         Tracker.shared.track("/home/profile", "Profile - Wallet Info")
     }
@@ -87,13 +87,13 @@ class ProfileViewController: UIViewController {
         navigationBar.heightAnchor.constraint(equalToConstant: 44).isActive = true
     }
 
-    private func setupEmojiView() {
-        view.addSubview(emojiView)
-        emojiView.translatesAutoresizingMaskIntoConstraints = false
-        emojiView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20).isActive = true
-        emojiView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20).isActive = true
-        emojiView.heightAnchor.constraint(equalToConstant: 38).isActive = true
-        emojiView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: 25).isActive = true
+    private func setupEmojiIdView() {
+        view.addSubview(emojiIdView)
+        emojiIdView.translatesAutoresizingMaskIntoConstraints = false
+        emojiIdView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20).isActive = true
+        emojiIdView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20).isActive = true
+        emojiIdView.heightAnchor.constraint(equalToConstant: 38).isActive = true
+        emojiIdView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: 25).isActive = true
     }
 
     private func setupMiddleLabel() {
@@ -103,7 +103,7 @@ class ProfileViewController: UIViewController {
         middleLabel.translatesAutoresizingMaskIntoConstraints = false
         middleLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Theme.shared.sizes.appSidePadding).isActive = true
         middleLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Theme.shared.sizes.appSidePadding).isActive = true
-        middleLabel.topAnchor.constraint(equalTo: emojiView.bottomAnchor, constant: 20).isActive = true
+        middleLabel.topAnchor.constraint(equalTo: emojiIdView.bottomAnchor, constant: 20).isActive = true
     }
 
     private func setupQRContainer() {
@@ -136,8 +136,8 @@ class ProfileViewController: UIViewController {
 
             self.emojis = emojis
 
-            emojiView.setupView(pubKey: pubKey, textCentered: true, inViewController: self)
-            emojiView.blackoutParent = view
+            emojiIdView.setupView(pubKey: pubKey, textCentered: true, inViewController: self)
+            emojiIdView.blackoutParent = view
         }
     }
 

--- a/MobileWallet/Screens/Send/AddNote/AddNoteViewController.swift
+++ b/MobileWallet/Screens/Send/AddNote/AddNoteViewController.swift
@@ -92,38 +92,11 @@ class AddNoteViewController: UIViewController, UITextViewDelegate, SlideViewDele
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         scrollView.delegate = self
         setup()
         hideKeyboardWhenTappedAroundOrSwipedDown(view: attachmentContainer)
+        displayAliasOrEmojiId()
         Tracker.shared.track("/home/send_tari/add_note", "Send Tari - Add Note")
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        guard let wallet = TariLib.shared.tariWallet, let pubKey = publicKey else {
-            return
-        }
-
-        do {
-            guard let contact = try wallet.contacts.0?.find(publicKey: pubKey) else { return }
-            if contact.alias.0.trimmingCharacters(in: .whitespaces).isEmpty {
-                try navigationBar.showEmoji(pubKey, animated: true)
-            } else {
-                navigationBar.title = contact.alias.0
-            }
-        } catch {
-            do {
-                try navigationBar.showEmoji(pubKey, animated: true)
-            } catch {
-                UserFeedback.shared.error(
-                    title: NSLocalizedString("navigation_bar.error.show_emoji.title", comment: "Navigation bar"),
-                    description: NSLocalizedString("navigation_bar.error.show_emoji.description", comment: "Navigation bar"),
-                    error: error
-                )
-            }
-        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -145,8 +118,32 @@ class AddNoteViewController: UIViewController, UITextViewDelegate, SlideViewDele
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        navigationBar.hideEmoji(animated: false)
         navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+    }
+
+    private func displayAliasOrEmojiId() {
+        guard let wallet = TariLib.shared.tariWallet, let pubKey = publicKey else {
+            return
+        }
+
+        do {
+            guard let contact = try wallet.contacts.0?.find(publicKey: pubKey) else { return }
+            if contact.alias.0.trimmingCharacters(in: .whitespaces).isEmpty {
+                try navigationBar.showEmojiId(pubKey, inViewController: self)
+            } else {
+                navigationBar.title = contact.alias.0
+            }
+        } catch {
+            do {
+                try navigationBar.showEmojiId(pubKey, inViewController: self)
+            } catch {
+                UserFeedback.shared.error(
+                    title: NSLocalizedString("navigation_bar.error.show_emoji.title", comment: "Navigation bar"),
+                    description: NSLocalizedString("navigation_bar.error.show_emoji.description", comment: "Navigation bar"),
+                    error: error
+                )
+            }
+        }
     }
 
     func setSendButtonState() {

--- a/MobileWallet/UIElements/EmojiIdView.swift
+++ b/MobileWallet/UIElements/EmojiIdView.swift
@@ -38,7 +38,7 @@
 
 import UIKit
 
-class EmoticonView: UIView {
+class EmojiIdView: UIView {
 
     // var containerView = UIView()
     weak var blackoutParent: UIView?
@@ -80,7 +80,7 @@ class EmoticonView: UIView {
         }
     }
 
-    private var superVc: UIViewController?
+    private var superVC: UIViewController?
 
     func setupView(pubKey: PublicKey,
                    textCentered: Bool,
@@ -92,8 +92,8 @@ class EmoticonView: UIView {
         self.backgroundColor = .clear
         self.cornerRadius = cornerRadius
         blackoutView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tap(_:))))
-        superVc = vc
-        superVc?.navigationController?.navigationBar.layer.zPosition = 0
+        superVC = vc
+        superVC?.navigationController?.navigationBar.layer.zPosition = 0
         emojiText = pubKey.emojis.0
         pubKeyHex = pubKey.hex.0
         blackoutWhileExpanded = showContainerViewBlur
@@ -198,7 +198,7 @@ class EmoticonView: UIView {
         tapActionIsDisabled = true
         expanded = true
         //If they're typing somewhere, close the keyboard
-        superVc?.view.endEditing(true)
+        superVC?.view.endEditing(true)
         // fade out label container
         // fade in blackout
         fadeView(view: condensedEmojiIdContainer, fadeOut: true)
@@ -345,7 +345,7 @@ class EmoticonView: UIView {
     override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
         if newWindow == nil {
-            superVc?.navigationController?.navigationBar.layer.zPosition = 0
+            superVC?.navigationController?.navigationBar.layer.zPosition = 0
             hideCopyEmojiIdButton()
         }
     }
@@ -367,7 +367,7 @@ class EmoticonView: UIView {
 
 // MARK: blackout behavior
 
-extension EmoticonView {
+extension EmojiIdView {
 
     private func showCopyEmojiIdButton(completion: (() -> Void)? = nil) {
         emojiMenu.alpha = 0.0
@@ -508,7 +508,7 @@ private class EmojiMenuView: UIView {
 
 // MARK: "COPIED" function & view
 
-extension EmoticonView {
+extension EmojiIdView {
 
     func copyToClipboard(string: String) {
         let board = UIPasteboard.general

--- a/MobileWallet/UIElements/NavigationBar.swift
+++ b/MobileWallet/UIElements/NavigationBar.swift
@@ -51,7 +51,7 @@ class NavigationBar: UIView, NavigationBarProtocol {
         case custom(_ value: CGFloat)
     }
 
-    var emoji: EmoticonView?
+    var emojiIdView: EmojiIdView! = EmojiIdView()
 
     let titleLabel = UILabel()
     let backButton = UIButton()
@@ -102,6 +102,7 @@ class NavigationBar: UIView, NavigationBarProtocol {
         setupTitle()
         setupBackButton()
         setupRightButton()
+        clipsToBounds = false
     }
 
     required init?(coder: NSCoder) {
@@ -156,43 +157,41 @@ class NavigationBar: UIView, NavigationBarProtocol {
         rightButton.addTarget(self, action: #selector(rightButtonAction(_sender:)), for: .touchUpInside)
     }
 
-    func showEmoji(_ publicKey: PublicKey, animated: Bool = true) throws {
+    func showEmojiId(_ publicKey: PublicKey, inViewController: UIViewController) throws {
         let ( _, emojisError) = publicKey.emojis
         guard emojisError == nil else { throw emojisError! }
-        if emoji == nil { emoji = EmoticonView() }
+        emojiIdView.setupView(pubKey: publicKey,
+                              textCentered: true,
+                              inViewController: inViewController)
 
-        if let emojiView = emoji {
-            emojiView.setupView(pubKey: publicKey,
-                                textCentered: true)
-
-            emojiView.tapToExpand = { expanded in
-                UIView.animate(withDuration: CATransaction.animationDuration()) { [weak self] in
-                    self?.backButton.alpha = expanded ? 0.0 : 1.0
-                }
+        emojiIdView.tapToExpand = { expanded in
+            UIView.animate(withDuration: CATransaction.animationDuration()) { [weak self] in
+                self?.backButton.alpha = expanded ? 0.0 : 1.0
             }
-
-            emojiView.alpha = 0.0
-            if let window = UIApplication.shared.keyWindow {
-                window.addSubview(emojiView)
-                emojiView.translatesAutoresizingMaskIntoConstraints = false
-                emojiView.topAnchor.constraint(equalTo: window.safeAreaLayoutGuide.topAnchor, constant: 27).isActive = true
-                emojiView.leadingAnchor.constraint(equalTo: window.leadingAnchor, constant: Theme.shared.sizes.appSidePadding).isActive = true
-                emojiView.trailingAnchor.constraint(equalTo: window.trailingAnchor, constant: -Theme.shared.sizes.appSidePadding).isActive = true
-            }
-
-            UIView.animate(withDuration: animated ? CATransaction.animationDuration() : 0.0, delay: CATransaction.animationDuration(), options: .curveLinear, animations: {
-                emojiView.alpha = 1.0
-            }, completion: nil)
         }
+        addSubview(emojiIdView)
+        emojiIdView.translatesAutoresizingMaskIntoConstraints = false
+        emojiIdView.topAnchor.constraint(
+            equalTo: safeAreaLayoutGuide.topAnchor,
+            constant: 27
+        ).isActive = true
+        emojiIdView.leadingAnchor.constraint(
+            equalTo: leadingAnchor,
+            constant: Theme.shared.sizes.appSidePadding
+        ).isActive = true
+        emojiIdView.trailingAnchor.constraint(
+            equalTo: trailingAnchor,
+            constant: -Theme.shared.sizes.appSidePadding
+        ).isActive = true
     }
 
     func hideEmoji(animated: Bool = true) {
-        UIView.animate(withDuration: animated ? CATransaction.animationDuration() : 0.0, animations: { [weak self] in
-            self?.emoji?.alpha = 0.0
-
+        UIView.animate(withDuration: animated ? CATransaction.animationDuration() : 0.0, animations: {
+            [weak self] in
+            self?.emojiIdView.alpha = 0.0
         }) { [weak self] _ in
-            self?.emoji?.removeFromSuperview()
-            self?.emoji = nil
+            self?.emojiIdView.removeFromSuperview()
+            self?.emojiIdView = nil
         }
     }
 


### PR DESCRIPTION
## Description
Fixes a bug where condensed emoji id showed on top of the the Giphy search view controller in add note screen tari-project/wallet-ios#560. File and variable name improvements.

Transaction fee section in in add amount screen used to hide/show every time a digit was entered. That behaviour got improved.

## Motivation and Context
tari-project/wallet-ios#560

## How Has This Been Tested?
On sim and device.

## Screenshots and/or video clip
![Screen Shot 2020-08-17 at 16 23 29](https://user-images.githubusercontent.com/2969501/90400993-00c00a80-e0a6-11ea-945e-411a8a4ea46a.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [ ] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
