### PR TITLE
AddNote screen loading state

### DIFF
--- a/MobileWallet/Screens/Send/SendingTari/SendingTariViewController.swift
+++ b/MobileWallet/Screens/Send/SendingTari/SendingTariViewController.swift
@@ -625,17 +625,19 @@ class SendingTariViewController: UIViewController {
     }
 
     private func sendTransaction() {
-        let wallet = TariLib.shared.tariWallet!
-        do {
-            txId = try wallet.sendTransaction(
-                destination: recipientPubKey,
-                amount: amount,
-                fee: wallet.calculateTransactionFee(amount),
-                message: note
-            )
-            startListeningForWalletEvents()
-        } catch {
-            completionStatus = .sendError(error: error)
+        TariLib.shared.waitIfWalletIsRestarting { [weak self] (_) in
+            guard let self = self, let wallet = TariLib.shared.tariWallet else { return }
+            do {
+                self.txId = try wallet.sendTransaction(
+                    destination: self.recipientPubKey,
+                    amount: self.amount,
+                    fee: wallet.calculateTransactionFee(self.amount),
+                    message: self.note
+                )
+                self.startListeningForWalletEvents()
+            } catch {
+                self.completionStatus = .sendError(error: error)
+            }
         }
     }
 

--- a/MobileWallet/UIElements/EmojiIdView.swift
+++ b/MobileWallet/UIElements/EmojiIdView.swift
@@ -363,6 +363,11 @@ class EmojiIdView: UIView {
         }
         return super.hitTest(point, with: event)
     }
+
+    deinit {
+        UIApplication.shared.menuTabBarController?.tabBar.alpha = 1
+        UIApplication.shared.menuTabBarController?.tabBar.isUserInteractionEnabled = true
+    }
 }
 
 // MARK: blackout behavior


### PR DESCRIPTION
## Description
added loading state for addNote screen after finish sliding send button
added show/hide animation for giphy carousel on addNote screen

## Motivation and Context
design requirements

## How Has This Been Tested?
manually

## Screenshots and/or video clip
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/60744748/90402263-e129e180-e0a7-11ea-9f31-4e671c5da093.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
