### PR TITLE
Fix for navigation after failed send

### DIFF
--- a/MobileWallet/Screens/Send/SendingTari/SendingTariViewController.swift
+++ b/MobileWallet/Screens/Send/SendingTari/SendingTariViewController.swift
@@ -739,12 +739,12 @@ class SendingTariViewController: UIViewController {
             }
         ) {
             [weak self] _ in
-            // display error
-            self?.displayErrorFeedbackAndTrackEvent()
-            // return to home
             // return to home
             self?.navigationController?.dismiss(animated: true, completion: {
+                [weak self] in
                 UIApplication.shared.menuTabBarController?.setTab(.home)
+                // display error
+                self?.displayErrorFeedbackAndTrackEvent()
             })
         }
     }


### PR DESCRIPTION
## Description
A possible fix for the bug that causes the app to get stuck at the sending screen after a failed send attempt.

## Motivation and Context
https://drive.google.com/file/d/1Whkpa_qqI-oCUN9udggfgg0Ao4IjOmRt/view?usp=sharing

## How Has This Been Tested?
On device.

## Screenshots and/or video clip
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [ ] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
