### PR TITLE
backup prompt fix

### DIFF
--- a/MobileWallet/Backup/BackupPrompts.swift
+++ b/MobileWallet/Backup/BackupPrompts.swift
@@ -159,7 +159,9 @@ private class BackupPrompts {
             guard incomingTxs >= triggers.numberOfIncomingTransactions &&
             balance.rawValue >= triggers.totalBalance.rawValue &&
                 ICloudBackup.shared.isValidBackupExists() == triggers.hasConnectediCloud &&
-                (ICloudBackup.shared.lastBackup?.isEncrypted ?? false) == triggers.backupIsEncrypted else {
+                (ICloudBackup.shared.lastBackup?.isEncrypted ?? false) == triggers.backupIsEncrypted &&
+                !ICloudBackup.shared.iCloudBackupsIsOn
+            else {
                 continue
             }
 


### PR DESCRIPTION

## Description
prompt modal do not show up if  iCloud backup is on

## Motivation and Context
https://github.com/tari-project/wallet-ios/issues/579

## How Has This Been Tested?
manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
