### PR TITLE
Possible fix for the blank screen after successful send.

### DIFF
--- a/MobileWallet/Screens/Send/SendingTari/SendingTariViewController.swift
+++ b/MobileWallet/Screens/Send/SendingTari/SendingTariViewController.swift
@@ -794,7 +794,12 @@ class SendingTariViewController: UIViewController {
             fromProgress: pauseLottieAnimationAt,
             toProgress: 1,
             loopMode: .playOnce
-        )
+        ) {
+            [weak self] _ in
+            // return to home
+            UIApplication.shared.menuTabBarController?.setTab(.home)
+            self?.dismiss(animated: true)
+        }
         // fade out title views and progress bars
         UIView.animate(
             withDuration: 1,
@@ -808,13 +813,7 @@ class SendingTariViewController: UIViewController {
                 self?.progressBar2View.alpha = 0
                 self?.progressBar3View.alpha = 0
             }
-        ) {
-            [weak self] _ in
-            // return to home
-            self?.navigationController?.dismiss(animated: true, completion: {
-                UIApplication.shared.menuTabBarController?.setTab(.home)
-            })
-        }
+        )
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A possible fix for the bug that causes the send flow to get stuck after the sending animation completes.

## Motivation and Context
tari-project/wallet-ios#588

## How Has This Been Tested?
Manually on sim.

## Screenshots and/or video clip
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [ ] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
