### PR TITLE
navigation with telegram link from TTL store

### DIFF
--- a/MobileWallet/UIElements/WebBrowserView/WebBrowserViewController.swift
+++ b/MobileWallet/UIElements/WebBrowserView/WebBrowserViewController.swift
@@ -41,6 +41,10 @@
 import WebKit
 
 class WebBrowserViewController: UIViewController {
+    private enum UniversalLinkAppPrefix: String, CaseIterable {
+        case telegram = "https://t.me"
+    }
+
     private let webView = WKWebView()
     private let navigationBar = UIView()
     private let navigationPanel = UIView()
@@ -110,6 +114,26 @@ extension WebBrowserViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         titleLabel.text = webView.title
         updateButtons()
+    }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        if let url = navigationAction.request.url {
+            if UniversalLinkAppPrefix.allCases.first(where: { prefix -> Bool in
+                return url.absoluteString.hasPrefix(prefix.rawValue)
+            }) != nil {
+                openCustomApp(url: url)
+                decisionHandler(.cancel)
+                return
+            }
+        }
+        decisionHandler(.allow)
+    }
+
+    private func openCustomApp(url: URL) {
+        let application = UIApplication.shared
+        if application.canOpenURL(url) {
+            application.open(url, options: [:], completionHandler: nil)
+        }
     }
 
     private func updateButtons() {


### PR DESCRIPTION

## Description
fixed unable to navigate to Telegram using the links from within the TTL store

## Motivation and Context
wallet-ios #591

## How Has This Been Tested?
manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
