### PR TITLE
Close keyboard for user feedback dialog.

### DIFF
--- a/MobileWallet/Common/UserFeedback/UserFeedback.swift
+++ b/MobileWallet/Common/UserFeedback/UserFeedback.swift
@@ -58,6 +58,15 @@ class UserFeedback {
         return attributes
     }
 
+    private func closeKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIApplication.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
+    }
+
     func error(title: String, description: String, error: Error? = nil, onClose: (() -> Void)? = nil) {
         let errorFeedbackView = FeedbackView()
 
@@ -81,6 +90,7 @@ class UserFeedback {
         attributes.screenInteraction =  onClose == nil ? .dismiss : .absorbTouches
 
         SwiftEntryKit.display(entry: errorFeedbackView, using: attributes)
+        closeKeyboard()
         TariLogger.error("User feedback: title=\(title) description=\(description)", error: error)
     }
 
@@ -97,6 +107,7 @@ class UserFeedback {
         attributes.entranceAnimation = .init(translate: .init(duration: 0.25, anchorPosition: .bottom, spring: .init(damping: 1, initialVelocity: 0)))
 
         SwiftEntryKit.display(entry: infoFeedbackView, using: attributes)
+        closeKeyboard()
         TariLogger.verbose("User feedback: title=\(title) description=\(description)")
     }
 
@@ -113,6 +124,7 @@ class UserFeedback {
         attributes.screenInteraction = .forward
 
         SwiftEntryKit.display(entry: successFeedbackView, using: attributes)
+        closeKeyboard()
         TariLogger.verbose("User success feedback: title=\(title)")
     }
 
@@ -139,6 +151,7 @@ class UserFeedback {
         attributes.screenInteraction = .absorbTouches
 
         SwiftEntryKit.display(entry: ctaFeedbackView, using: attributes)
+        closeKeyboard()
         TariLogger.verbose("User call to action: title=\(title) description=\(description)")
     }
 
@@ -162,6 +175,7 @@ class UserFeedback {
         attributes.entryInteraction = .absorbTouches
 
         SwiftEntryKit.display(entry: successFeedbackView, using: attributes)
+        closeKeyboard()
         TariLogger.verbose("User call accept user input: title=\(title)")
     }
 
@@ -216,6 +230,7 @@ class UserFeedback {
 
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
         SwiftEntryKit.display(entry: containerView, using: attributes)
+        closeKeyboard()
         TariLogger.verbose("User call to action store")
     }
 
@@ -241,6 +256,7 @@ class UserFeedback {
         attributes.entranceAnimation = .init(translate: .init(duration: 0.25, anchorPosition: .bottom, spring: .init(damping: 1, initialVelocity: 0)))
 
         SwiftEntryKit.display(entry: infoFeedbackView, using: attributes)
+        closeKeyboard()
     }
 
     func openWebBrowser(url: URL) {

--- a/MobileWallet/Screens/Home/TransactionHistory/TxGifManager.swift
+++ b/MobileWallet/Screens/Home/TransactionHistory/TxGifManager.swift
@@ -48,7 +48,7 @@ class TxGifManager {
     enum TxGifManagerError: Error {
         case downloadTimeout
     }
-    
+
     static let shared = TxGifManager()
 
     private var cachedMedia = NSCache<NSString, GPHMedia>()

--- a/MobileWallet/TariLib/Wrappers/Transactions/Protocols/TxProtocol.swift
+++ b/MobileWallet/TariLib/Wrappers/Transactions/Protocols/TxProtocol.swift
@@ -105,12 +105,12 @@ extension TxProtocol {
         }
         return false
     }
-    
+
     var isPending: Bool {
         if let _ = self as? PendingInboundTx {
             return true
         }
-        
+
         if let _ = self as? PendingOutboundTx {
             return true
         }


### PR DESCRIPTION
## Description
Closes a possibly open soft keyboard when the user feedback dialog shows.

## Motivation and Context
It can cause a UI-lock-like state if you receive a dialog when the keyboard is open, for example in the add recipient screen.

## How Has This Been Tested?
Manually on device.

## Screenshots and/or video clip
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [ ] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
