### PR TITLE
Added confirmation settings

### DIFF
--- a/MobileWallet/TariLib/Wrappers/Wallet.swift
+++ b/MobileWallet/TariLib/Wrappers/Wallet.swift
@@ -659,6 +659,27 @@ class Wallet {
         }
         return result
     }
+    
+    func getConfirmations() throws -> UInt64 {
+        var errorCode: Int32 = -1
+        let result = withUnsafeMutablePointer(to: &errorCode, { error in
+                 wallet_get_num_confirmations_required(ptr, error)
+            })
+        guard errorCode == 0 else {
+            throw WalletErrors.generic(errorCode)
+        }
+        return result
+    }
+    
+    func setConfirmations(number: UInt64) throws {
+        var errorCode: Int32 = -1
+        withUnsafeMutablePointer(to: &errorCode, { error in
+                wallet_set_num_confirmations_required(ptr, number, error)
+        })
+        guard errorCode == 0 else {
+            throw WalletErrors.generic(errorCode)
+        }
+    }
 
     deinit {
         TariLogger.warn("Wallet destroy")

--- a/MobileWallet/TariLib/wallet.h
+++ b/MobileWallet/TariLib/wallet.h
@@ -463,6 +463,13 @@ unsigned long long wallet_get_pending_outgoing_balance(struct TariWallet *wallet
 // Get a fee estimate from a TariWallet for a given amount
 unsigned long long wallet_get_fee_estimate(struct TariWallet *wallet, unsigned long long amount, unsigned long long fee_per_gram, unsigned long long num_kernels, unsigned long long num_outputs, int* error_out);
 
+// Get the number of mining confirmations by the wallet transaction service
+unsigned long long wallet_get_num_confirmations_required(struct TariWallet *wallet, int* error_out);
+
+// Set the number of mining confirmations by the wallet transaction service
+void wallet_set_num_confirmations_required(struct TariWallet *wallet, unsigned long long num, int* error_out);
+
+
 // Sends a TariPendingOutboundTransaction
 unsigned long long wallet_send_transaction(struct TariWallet *wallet, struct TariPublicKey *destination, unsigned long long amount, unsigned long long fee_per_gram,const char *message,int* error_out);
 


### PR DESCRIPTION
## Description
Added methods to get and set the number of required confirmations for the wallet.

Linked to PR:
https://github.com/tari-project/tari/pull/2624/

## Motivation and Context
New FFI methods, requires latest library build

## How Has This Been Tested?

## Screenshots and/or video clip

## Types of changes
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [ ] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
