### PR TITLE
Bug fixes

### DIFF
--- a/MobileWallet/Screens/Home/HomeViewController.swift
+++ b/MobileWallet/Screens/Home/HomeViewController.swift
@@ -131,7 +131,6 @@ class HomeViewController: UIViewController {
         overrideUserInterfaceStyle = .light
         setup()
         setupKeyServer()
-        setupConnectionStatusMonitor()
         Tracker.shared.track("/home", "Home - Transaction List")
         TariEventBus.onMainThread(self, eventType: .balanceUpdate) {
             [weak self] (_) in
@@ -155,6 +154,7 @@ class HomeViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        setupConnectionStatusMonitor()
         TariEventBus.onMainThread(self, eventType: .walletStateChanged) {
             [weak self]
             (sender) in

--- a/MobileWallet/UIElements/SystemMenuTableViewCell/SystemMenuTableViewCell.swift
+++ b/MobileWallet/UIElements/SystemMenuTableViewCell/SystemMenuTableViewCell.swift
@@ -179,10 +179,8 @@ class SystemMenuTableViewCell: UITableViewCell {
         switcher.isHidden = !item.hasSwitch
         arrow.isHidden = item.hasSwitch
         titleLabel.text = item.title
-        if item.isDestructive {
-            titleLabel.textColor = Theme.shared.colors.warning
-            arrow.image = Theme.shared.images.forwardArrowRed
-        }
+        titleLabel.textColor = item.isDestructive ? Theme.shared.colors.warning : Theme.shared.colors.navigationBarTint
+        arrow.image = item.isDestructive ? Theme.shared.images.forwardArrowRed : Theme.shared.images.forwardArrow
         disableCellInProgress = item.disableCellInProgress
         mark = item.mark
         markDescription = item.markDescription
@@ -241,7 +239,6 @@ extension SystemMenuTableViewCell {
 
     private func setupArrow() {
         contentView.addSubview(arrow)
-        arrow.image = Theme.shared.images.forwardArrow
 
         arrow.translatesAutoresizingMaskIntoConstraints = false
         arrowWidthConstraint = arrow.widthAnchor.constraint(equalToConstant: 8)


### PR DESCRIPTION
- fixed issue with unresponsive status dot on the home screen. Now, it will update it's status even when user change the base node in settings
- fixed issue with reusing cells in settings. Now, cells will not inherit red text and arrow color from the reused cell

<!--- Provide a general summary of your changes in the Title above -->

## Screenshots and/or video clip
<!--- Only applicable if this PR has UI changes -->
<!--- Please upload screenshots from simulator of all device screen sizes -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
