### PR TITLE
Bug fixes

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -508,6 +508,8 @@
 		3AD3E0352696F471008FE1B6 /* ConnectionIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A811EEE26957856003D0DF3 /* ConnectionIndicatorView.swift */; };
 		3AD3E0362696F47C008FE1B6 /* TooltipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A811EF02695BAEE003D0DF3 /* TooltipView.swift */; };
 		3AD3E0372696F47C008FE1B6 /* TooltipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A811EF02695BAEE003D0DF3 /* TooltipView.swift */; };
+		3ADA73DD270A02B900D50E3B /* WalletSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADA73DC270A02B900D50E3B /* WalletSettings.swift */; };
+		3ADA73DF270A02DF00D50E3B /* WalletSettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADA73DE270A02DF00D50E3B /* WalletSettingsManager.swift */; };
 		3ADEBF5D26A54FA500E87C84 /* SelectBaseNodeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADEBF5C26A54FA500E87C84 /* SelectBaseNodeModel.swift */; };
 		3ADEBF5E26A54FA500E87C84 /* SelectBaseNodeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADEBF5C26A54FA500E87C84 /* SelectBaseNodeModel.swift */; };
 		3ADEBF5F26A54FA500E87C84 /* SelectBaseNodeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADEBF5C26A54FA500E87C84 /* SelectBaseNodeModel.swift */; };
@@ -880,6 +882,8 @@
 		3ACDA70826B031CB00F138B8 /* RestoreWalletFromSeedsProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreWalletFromSeedsProgressView.swift; sourceTree = "<group>"; };
 		3ACDA70D26B0320900F138B8 /* RestoreWalletFromSeedsProgressModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreWalletFromSeedsProgressModel.swift; sourceTree = "<group>"; };
 		3ACFDD1C26E8C1A900C5E1EA /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
+		3ADA73DC270A02B900D50E3B /* WalletSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSettings.swift; sourceTree = "<group>"; };
+		3ADA73DE270A02DF00D50E3B /* WalletSettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSettingsManager.swift; sourceTree = "<group>"; };
 		3ADEBF5C26A54FA500E87C84 /* SelectBaseNodeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectBaseNodeModel.swift; sourceTree = "<group>"; };
 		3ADEBF6126A59A5900E87C84 /* AddBaseNodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBaseNodeViewController.swift; sourceTree = "<group>"; };
 		3ADEBF6526A5B5A500E87C84 /* AddBaseNodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBaseNodeView.swift; sourceTree = "<group>"; };
@@ -1089,6 +1093,7 @@
 		006D211B23CEDEEE007D1C10 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				3ADA73DA270A029B00D50E3B /* Settings */,
 				3A72DC3B26DF9FF700E0BC43 /* Network */,
 				00A66526243C766D0046E730 /* ConnectionMonitor.swift */,
 				009DFCA62473E33F0061DBC9 /* DeepLinkParams.swift */,
@@ -1100,7 +1105,6 @@
 				00F53A632428E44700448466 /* StorageCleanup.swift */,
 				00A057AE23D875840029C22A /* TariEventBus.swift */,
 				00369D802426080D00BAB95B /* TariLogger.swift */,
-				00DD160A241CCE0600C955B4 /* TariSettings.swift */,
 				619190C6EBD050DC647D1D7B /* UTXO.swift */,
 				3ACFDD1C26E8C1A900C5E1EA /* AppInfo.swift */,
 			);
@@ -1722,6 +1726,24 @@
 				3ACDA70826B031CB00F138B8 /* RestoreWalletFromSeedsProgressView.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		3ADA73DA270A029B00D50E3B /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				00DD160A241CCE0600C955B4 /* TariSettings.swift */,
+				3ADA73DB270A02AC00D50E3B /* Wallet */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		3ADA73DB270A02AC00D50E3B /* Wallet */ = {
+			isa = PBXGroup;
+			children = (
+				3ADA73DC270A02B900D50E3B /* WalletSettings.swift */,
+				3ADA73DE270A02DF00D50E3B /* WalletSettingsManager.swift */,
+			);
+			path = Wallet;
 			sourceTree = "<group>";
 		};
 		3ADEBF6026A59A4700E87C84 /* AddBaseNode */ = {
@@ -2443,6 +2465,7 @@
 				37547D522460165500EB59CC /* UIApplication+KeyWindow.swift in Sources */,
 				00A994332396434B007D9990 /* QRButton.swift in Sources */,
 				3A72DC4126DFA1E100E0BC43 /* NetworkSettings.swift in Sources */,
+				3ADA73DD270A02B900D50E3B /* WalletSettings.swift in Sources */,
 				00A66523243B3E380046E730 /* ErrorView.swift in Sources */,
 				3ADEBF6626A5B5A500E87C84 /* AddBaseNodeView.swift in Sources */,
 				375DB1E0246E90D100B2BEF4 /* NavigationBar.swift in Sources */,
@@ -2465,6 +2488,7 @@
 				BFF1ED9D2408111000CC9EF6 /* SendingTariViewController.swift in Sources */,
 				3776080924B73500008167E8 /* Backup.swift in Sources */,
 				00369D7D24221ACB00BAB95B /* DeepLinkManager.swift in Sources */,
+				3ADA73DF270A02DF00D50E3B /* WalletSettingsManager.swift in Sources */,
 				37B5289424CB1E16008C80EB /* NetworkSpeedProvider.swift in Sources */,
 				001F6CEC2381A39300FA7002 /* CompletedTx.swift in Sources */,
 				3730E15124C884D500827DFA /* MenuTabBarController.swift in Sources */,

--- a/MobileWallet/Backup/ICloudBackup.swift
+++ b/MobileWallet/Backup/ICloudBackup.swift
@@ -145,9 +145,9 @@ class ICloudBackup: NSObject {
     }
 
     var iCloudBackupsIsOn: Bool {
-        get { NetworkManager.shared.selectedNetwork.isCloudBackupEnabled }
+        get { TariSettings.shared.walletSettings.isCloudBackupEnabled }
         set {
-            NetworkManager.shared.selectedNetwork.isCloudBackupEnabled = newValue
+            TariSettings.shared.walletSettings.isCloudBackupEnabled = newValue
             newValue ? BackupScheduler.shared.startObserveEvents() : BackupScheduler.shared.stopObserveEvents()
         }
     }
@@ -273,8 +273,7 @@ class ICloudBackup: NSObject {
             )
             restoreBackup(password: password, to: dbDirectory) { [weak self] error in
                 if error == nil {
-                    UserDefaults.Key.walletHasBeenIntroduced.set(true)
-                    UserDefaults.Key.authStepPassed.set(true)
+                    TariSettings.shared.walletSettings.configationState = .authorized
                     self?.iCloudBackupsIsOn = true
 
                     BackupScheduler.shared.startObserveEvents()

--- a/MobileWallet/Common/Persistant Data/GroupUserDefaults.swift
+++ b/MobileWallet/Common/Persistant Data/GroupUserDefaults.swift
@@ -41,4 +41,5 @@
 enum GroupUserDefaults {
     @UserDefault(key: "selectedNetworkName", suiteName: TariSettings.groupIndentifier) static var selectedNetworkName: String?
     @UserDefault(key: "networksSettings", suiteName: TariSettings.groupIndentifier) static var networksSettings: [NetworkSettings]?
+    @UserDefault(key: "walletSettings", suiteName: TariSettings.groupIndentifier) static var walletSettings: [WalletSettings]?
 }

--- a/MobileWallet/Common/UserDefaultsWrapper.swift
+++ b/MobileWallet/Common/UserDefaultsWrapper.swift
@@ -41,12 +41,9 @@
 import Foundation
 
 extension UserDefaults {
-    enum Key: String {
-        case walletHasBeenIntroduced
-        case authStepPassed
+    enum Key: String, CaseIterable {
         case isLastBackupFailed
         case backupOperationAborted
-        case hasVerifiedSeedPhrase
 
         func set<T>(_ value: T) {
             UserDefaults.standard.set(value, forKey: rawValue)
@@ -60,5 +57,9 @@ extension UserDefaults {
         func boolValue() -> Bool {
             UserDefaults.standard.bool(forKey: rawValue)
         }
+    }
+
+    func removeAll() {
+        UserDefaults.Key.allCases.forEach { UserDefaults.standard.removeObject(forKey: $0.rawValue) }
     }
 }

--- a/MobileWallet/Common/UserFeedback/UserFeedback.swift
+++ b/MobileWallet/Common/UserFeedback/UserFeedback.swift
@@ -180,8 +180,9 @@ class UserFeedback {
                 SwiftEntryKit.dismiss()
                 onCancel?()
             }, onAction: {
-                SwiftEntryKit.dismiss()
-                onAction()
+                SwiftEntryKit.dismiss {
+                    onAction()
+                }
             }
         )
 

--- a/MobileWallet/SceneDelegate.swift
+++ b/MobileWallet/SceneDelegate.swift
@@ -134,12 +134,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         UIApplication.shared.applicationIconBadgeNumber = 0
         ConnectionMonitor.shared.start()
         TariLib.shared.startTor()
-        // Only starts the wallet if it was stopped. Else wallet is started on the splash screen.
-        if TariLib.shared.isWalletExist {
-            onTorSuccess {
-                TariLib.shared.startWallet(seedWords: nil)
-            }
-        }
         if UserDefaults.Key.backupOperationAborted.boolValue()
             && ICloudBackup.shared.iCloudBackupsIsOn
             && !ICloudBackup.shared.inProgress {

--- a/MobileWallet/Screens/AppEntry/Splash/SplashViewControllerSetup.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/SplashViewControllerSetup.swift
@@ -100,11 +100,9 @@ extension SplashViewController {
 
         if TariLib.shared.isWalletExist {
             animationContainer.centerYAnchor.constraint(equalTo: generalContainer.centerYAnchor).isActive = true
-            walletExistsInitially = true
         } else {
             ticketTopLayoutConstraint = animationContainer.topAnchor.constraint(equalTo: generalContainer.topAnchor, constant: 19)
             ticketTopLayoutConstraint?.isActive = true
-            walletExistsInitially = false
         }
     }
 

--- a/MobileWallet/Screens/AppEntry/Splash/SplashViewControllerSetup.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/SplashViewControllerSetup.swift
@@ -165,7 +165,6 @@ extension SplashViewController {
 
     func setupCreateWalletButton() {
         createWalletButton.isHidden = true
-        createWalletButton.setTitle(localized("splash.create_wallet"), for: .normal)
         createWalletButton.addTarget(self, action: #selector(onCreateWalletTap), for: .touchUpInside)
         elementsContainer.addSubview(createWalletButton)
 

--- a/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/WalletCreationViewController.swift
@@ -199,6 +199,7 @@ class WalletCreationViewController: UIViewController {
                 Tracker.shared.track("/onboarding/create_emoji_id", "Onboarding - Create Emoji Id")
             }
         case .showEmojiId:
+            TariSettings.shared.walletSettings.configationState = .initialized
             hideSubviews { [weak self] in
                 self?.emojiIdView.shrink(animated: false)
                 self?.prepareSubviews(for: .localAuthentication)
@@ -241,7 +242,7 @@ class WalletCreationViewController: UIViewController {
     }
 
     private func successAuth() {
-        UserDefaults.Key.authStepPassed.set(true)
+        TariSettings.shared.walletSettings.configationState = .authorized
         hideSubviews { [weak self] in
             self?.prepareSubviews(for: .enableNotifications)
             self?.showEnableNotifications()

--- a/MobileWallet/Screens/Debug/AdvancedSettings/Select Network/SelectNetworkModel.swift
+++ b/MobileWallet/Screens/Debug/AdvancedSettings/Select Network/SelectNetworkModel.swift
@@ -68,7 +68,6 @@ final class SelectNetworkModel {
         guard viewModel.selectedIndex != selectedIndex else { return }
         TariLib.shared.stopWallet()
         NetworkManager.shared.selectedNetwork = networks[selectedIndex]
-        TariLib.shared.startWallet(seedWords: nil)
         AppRouter.moveToSplashScreen()
     }
 }

--- a/MobileWallet/Screens/Debug/AdvancedSettings/SelectBaseNode/SelectBaseNodeModel.swift
+++ b/MobileWallet/Screens/Debug/AdvancedSettings/SelectBaseNode/SelectBaseNodeModel.swift
@@ -55,7 +55,7 @@ final class SelectBaseNodeModel {
 
     var viewModel = ViewModel()
 
-    private let predefinedNodes: [BaseNode] = NetworkManager.shared.selectedNetwork.baseNodes.sorted { $0.name < $1.name }
+    private var predefinedNodes: [BaseNode] { NetworkManager.shared.selectedNetwork.baseNodes }
     private var avaiableNodes: [BaseNode] { NetworkManager.shared.selectedNetwork.allBaseNodes }
     private var selectedNodeIndex: Int?
 

--- a/MobileWallet/Screens/Home/HomeViewController.swift
+++ b/MobileWallet/Screens/Home/HomeViewController.swift
@@ -490,6 +490,11 @@ final class HomeViewController: UIViewController {
 
     private func setupConnectionStatusMonitor() {
 
+        let initialState = handle(connectionState: ConnectionMonitor.shared.state)
+
+        mainView.connectionIndicatorView.currentState = initialState.0
+        mainView.tooltipView.text = initialState.1
+
         let connectionMonitorStatus = TariEventBus
             .events(forType: .connectionMonitorStatusChanged)
             .compactMap { $0.object as? ConnectionMonitorState }

--- a/MobileWallet/Screens/Home/HomeViewController.swift
+++ b/MobileWallet/Screens/Home/HomeViewController.swift
@@ -483,7 +483,10 @@ final class HomeViewController: UIViewController {
         let navigationController = AlwaysPoppableNavigationController(rootViewController: sendVC)
         navigationController.setNavigationBarHidden(true, animated: false)
         navigationController.modalPresentationStyle = .fullScreen
-        UIApplication.shared.menuTabBarController?.present(navigationController, animated: true)
+
+        DispatchQueue.main.async {
+            UIApplication.shared.menuTabBarController?.present(navigationController, animated: true)
+        }
     }
 
     // MARK: - Busness Logic

--- a/MobileWallet/Screens/Home/HomeViewController.swift
+++ b/MobileWallet/Screens/Home/HomeViewController.swift
@@ -77,7 +77,7 @@ final class HomeViewController: UIViewController {
     private var networkCompatibilityCheckIsWaitingForWallet = false
 
     var isFirstIntroToWallet: Bool {
-        return !UserDefaults.Key.walletHasBeenIntroduced.boolValue()
+        TariSettings.shared.walletSettings.configationState != .ready
     }
 
     private var isTxViewFullScreen: Bool = false {
@@ -444,7 +444,7 @@ final class HomeViewController: UIViewController {
 
             // User swipes down for the first time
             if isFirstIntroToWallet {
-                UserDefaults.Key.walletHasBeenIntroduced.set(true)
+                TariSettings.shared.walletSettings.configationState = .ready
             }
 
             navigationController?.setNavigationBarHidden(true, animated: true)

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/RestoreWalletFromSeedsViewController.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/RestoreWalletFromSeedsViewController.swift
@@ -86,6 +86,7 @@ final class RestoreWalletFromSeedsViewController: SettingsParentViewController, 
             .store(in: &cancelables)
 
         mainView.onTapOnSubmitButton = { [weak self] in
+            _ = self?.mainView.resignFirstResponder()
             self?.model.startRestoringWallet()
         }
 

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/RestoreWalletFromSeedsView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/RestoreWalletFromSeedsView.swift
@@ -134,6 +134,6 @@ final class RestoreWalletFromSeedsView: KeyboardAvoidingContentView {
     }
 
     // MARK: - First Responder
-    
+
     override func resignFirstResponder() -> Bool { tokenView.resignFirstResponder() }
 }

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/RestoreWalletFromSeedsView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/RestoreWalletFromSeedsView.swift
@@ -132,4 +132,8 @@ final class RestoreWalletFromSeedsView: KeyboardAvoidingContentView {
     @objc private func onTapOnSubmitButtonAction() {
         onTapOnSubmitButton?()
     }
+
+    // MARK: - First Responder
+    
+    override func resignFirstResponder() -> Bool { tokenView.resignFirstResponder() }
 }

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenCollectionView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenCollectionView.swift
@@ -214,7 +214,7 @@ final class TokenCollectionView: UIView {
         let indexPath = IndexPath(item: tokenModels.count - 1, section: 0)
         collectionView.cellForItem(at: indexPath)?.becomeFirstResponder()
     }
-    
+
     // MARK: - First Responder
 
     override func resignFirstResponder() -> Bool {

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenCollectionView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenCollectionView.swift
@@ -77,7 +77,7 @@ final class TokenCollectionView: UIView {
 
     var tokens: AnyPublisher<[String], Never> {
         $tokenModels
-            .map { $0.map { $0.text }.filter {!$0.isEmpty } }
+            .map { $0.map(\.text).filter { !$0.isEmpty } }
             .eraseToAnyPublisher()
     }
 
@@ -213,6 +213,14 @@ final class TokenCollectionView: UIView {
     @objc private func onTapOutsideAction() {
         let indexPath = IndexPath(item: tokenModels.count - 1, section: 0)
         collectionView.cellForItem(at: indexPath)?.becomeFirstResponder()
+    }
+    
+    // MARK: - First Responder
+
+    override func resignFirstResponder() -> Bool {
+        let indexPath = IndexPath(item: tokenModels.count - 1, section: 0)
+        return collectionView.cellForItem(at: indexPath)?.resignFirstResponder() ?? false
+
     }
 }
 

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenInputView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenInputView.swift
@@ -112,6 +112,11 @@ final class TokenInputView: UICollectionViewCell {
             self?.textField.text = self?.onTextChange?(self?.textField.text ?? "")
         }
     }
+
+    override func resignFirstResponder() -> Bool {
+        textField.text = onEndEditing?(textField.text ?? "")
+        return textField.resignFirstResponder()
+    }
 }
 
 extension TokenInputView: UITextFieldDelegate {

--- a/MobileWallet/Screens/Settings/BackUpSettings/BackupWalletSettingsViewController.swift
+++ b/MobileWallet/Screens/Settings/BackUpSettings/BackupWalletSettingsViewController.swift
@@ -207,12 +207,7 @@ class BackupWalletSettingsViewController: SettingsParentTableViewController {
     }
 
     override func reloadTableViewWithAnimation() {
-        var writeDownSeedPhraseMark: SystemMenuTableViewCell.SystemMenuTableViewCellMark!
-        if UserDefaults.Key.hasVerifiedSeedPhrase.boolValue() {
-            writeDownSeedPhraseMark = .success
-        } else {
-            writeDownSeedPhraseMark = .attention
-        }
+        let writeDownSeedPhraseMark: SystemMenuTableViewCell.SystemMenuTableViewCellMark = TariSettings.shared.walletSettings.hasVerifiedSeedPhrase ? .success : .attention
         settingsSectionItems = [
             SystemMenuTableViewCellItem(
                 title: BackupWalletSettingsItem.iCloudBackups.rawValue,

--- a/MobileWallet/Screens/Settings/BackUpSettings/VerifyPhraseViewController.swift
+++ b/MobileWallet/Screens/Settings/BackUpSettings/VerifyPhraseViewController.swift
@@ -273,7 +273,7 @@ extension VerifyPhraseViewController {
     }
 
     @objc private func continueButtonAction() {
-        UserDefaults.Key.hasVerifiedSeedPhrase.set(true)
+        TariSettings.shared.walletSettings.hasVerifiedSeedPhrase = true
         let viewController = self.navigationController?.viewControllers.first {
             $0 is BackupWalletSettingsViewController
         }

--- a/MobileWallet/Tari.entitlements
+++ b/MobileWallet/Tari.entitlements
@@ -11,11 +11,14 @@
 	<key>com.apple.developer.icloud-services</key>
 	<array>
 		<string>CloudDocuments</string>
+		<string>CloudKit</string>
 	</array>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>
 		<string>iCloud.com.tari.wallet</string>
 	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.tari.wallet</string>

--- a/MobileWallet/TariLib/TariLib.swift
+++ b/MobileWallet/TariLib/TariLib.swift
@@ -301,10 +301,8 @@ class TariLib {
                 try FileManager.default.removeItem(at: logFile)
             }
             // remove all user defaults
-            let domain = Bundle.main.bundleIdentifier!
-            UserDefaults.standard.removePersistentDomain(forName: domain)
-            UserDefaults.standard.removePersistentDomain(forName: TariSettings.groupIndentifier)
-            UserDefaults.standard.synchronize()
+            UserDefaults.standard.removeAll()
+            NetworkManager.shared.removeSelectedNetworkSettings()
         } catch {
             fatalError()
         }

--- a/MobileWallet/TariLib/Wrappers/PublicKey.swift
+++ b/MobileWallet/TariLib/Wrappers/PublicKey.swift
@@ -100,7 +100,7 @@ class PublicKey {
             return ("", emojisError)
         }
 
-        return ("\(TariSettings.shared.deeplinkURI)://\(NetworkManager.shared.selectedNetwork)/eid/\(emojisPubkey)", nil)
+        return ("\(TariSettings.shared.deeplinkURI)://\(NetworkManager.shared.selectedNetwork.name)/eid/\(emojisPubkey)", nil)
     }
 
     var hexDeeplink: (String, Error?) {
@@ -109,7 +109,7 @@ class PublicKey {
             return ("", hexError)
         }
 
-        return ("\(TariSettings.shared.deeplinkURI)://\(NetworkManager.shared.selectedNetwork)/pubkey/\(hexPubkey)", nil)
+        return ("\(TariSettings.shared.deeplinkURI)://\(NetworkManager.shared.selectedNetwork.name)/pubkey/\(hexPubkey)", nil)
     }
 
     // TODO setup attributed string version with dots in the middle for shortened version in Common dir.
@@ -178,7 +178,7 @@ class PublicKey {
             throw PublicKeyError.invalidDeepLink
         }
 
-        let deeplinkPrefix = "\(TariSettings.shared.deeplinkURI)://\(NetworkManager.shared.selectedNetwork)"
+        let deeplinkPrefix = "\(TariSettings.shared.deeplinkURI)://\(NetworkManager.shared.selectedNetwork.name)"
 
         // Link is for a different network
         guard deeplink.hasPrefix(deeplinkPrefix) else {

--- a/MobileWallet/TariLib/Wrappers/Utils/Network/NetworkSettings.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/Network/NetworkSettings.swift
@@ -43,13 +43,13 @@ struct NetworkSettings: Codable, Equatable {
     let name: String
     let selectedBaseNode: BaseNode
     let customBaseNodes: [BaseNode]
-    let isCloudBackupEnabled: Bool
 
     static func == (lhs: Self, rhs: Self) -> Bool { lhs.name == rhs.name }
 }
 
 extension NetworkSettings {
-    func update(selectedBaseNode: BaseNode) -> Self { Self(name: name, selectedBaseNode: selectedBaseNode, customBaseNodes: customBaseNodes, isCloudBackupEnabled: isCloudBackupEnabled) }
-    func update(customBaseNodes: [BaseNode]) -> Self { Self(name: name, selectedBaseNode: selectedBaseNode, customBaseNodes: customBaseNodes, isCloudBackupEnabled: isCloudBackupEnabled) }
-    func update(isCloudBackupEnabled: Bool) -> Self { Self(name: name, selectedBaseNode: selectedBaseNode, customBaseNodes: customBaseNodes, isCloudBackupEnabled: isCloudBackupEnabled) }
+    func update(selectedBaseNode: BaseNode) -> Self { Self(name: name, selectedBaseNode: selectedBaseNode, customBaseNodes: customBaseNodes) }
+    func update(customBaseNodes: [BaseNode]) -> Self { Self(name: name, selectedBaseNode: selectedBaseNode, customBaseNodes: customBaseNodes) }
+    func update(isCloudBackupEnabled: Bool) -> Self { Self(name: name, selectedBaseNode: selectedBaseNode, customBaseNodes: customBaseNodes) }
+    func update(hasVerifiedSeedPhrase: Bool) -> Self { Self(name: name, selectedBaseNode: selectedBaseNode, customBaseNodes: customBaseNodes) }
 }

--- a/MobileWallet/TariLib/Wrappers/Utils/Network/TariNetwork.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/Network/TariNetwork.swift
@@ -52,11 +52,11 @@ extension TariNetwork {
 
     var allBaseNodes: [BaseNode] { baseNodes.sorted { $0.name < $1.name } + customBaseNodes }
 
-    var settings: NetworkSettings {
+    private var settings: NetworkSettings {
         let allSettings = GroupUserDefaults.networksSettings ?? []
 
         guard let existingSettings = allSettings.first(where: { $0.name == name }) else {
-            let newSettings = NetworkSettings(name: name, selectedBaseNode: baseNodes.randomElement()!, customBaseNodes: [], isCloudBackupEnabled: false)
+            let newSettings = NetworkSettings(name: name, selectedBaseNode: baseNodes.randomElement()!, customBaseNodes: [])
             update(settings: newSettings)
             return newSettings
         }
@@ -71,11 +71,6 @@ extension TariNetwork {
     var customBaseNodes: [BaseNode] {
         get { settings.customBaseNodes }
         set { update(settings: settings.update(customBaseNodes: newValue)) }
-    }
-
-    var isCloudBackupEnabled: Bool {
-        get { settings.isCloudBackupEnabled }
-        set { update(settings: settings.update(isCloudBackupEnabled: newValue)) }
     }
 
     func randomNode() throws -> BaseNode {

--- a/MobileWallet/TariLib/Wrappers/Utils/Network/TariNetwork.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/Network/TariNetwork.swift
@@ -50,7 +50,7 @@ extension TariNetwork {
         case noPredefinedNodes
     }
 
-    var allBaseNodes: [BaseNode] { baseNodes + customBaseNodes }
+    var allBaseNodes: [BaseNode] { baseNodes.sorted { $0.name < $1.name } + customBaseNodes }
 
     var settings: NetworkSettings {
         let allSettings = GroupUserDefaults.networksSettings ?? []

--- a/MobileWallet/TariLib/Wrappers/Utils/Settings/TariSettings.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/Settings/TariSettings.swift
@@ -48,7 +48,10 @@ enum AppEnvironment {
 }
 
 struct TariSettings {
+
     static let shared = TariSettings()
+
+    let walletSettings = WalletSettingsManager()
 
     let discoveryTimeoutSec: UInt64 = 20
     let safMessageDurationSec: UInt64 = 10800

--- a/MobileWallet/TariLib/Wrappers/Utils/Settings/Wallet/WalletSettings.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/Settings/Wallet/WalletSettings.swift
@@ -1,8 +1,8 @@
-//  NetworkManager.swift
+//  WalletSettings.swift
 
 /*
 	Package MobileWallet
-	Created by Adrian Truszczynski on 01/09/2021
+	Created by Adrian Truszczynski on 03/10/2021
 	Using Swift 5.0
 	Running on macOS 12.0
 
@@ -38,46 +38,29 @@
 	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-import Combine
+struct WalletSettings: Codable, Equatable {
 
-final class NetworkManager {
-
-    // MARK: - Properties
-
-    static let shared = NetworkManager()
-
-    @Published var selectedNetwork: TariNetwork
-
-    private static var defaultNetwork: TariNetwork { .weatherwax }
-    private var cancelables = Set<AnyCancellable>()
-
-    // MARK: - Initializers
-
-    init() {
-        selectedNetwork = Self.setupNetwork()
-        setupFeedbacks()
+    enum  WalletConfigurationState: Codable {
+        /// Wallet wasn't configure
+        case notConfigured
+        /// Walet was created
+        case initialized
+        /// User finished authorisation flow
+        case authorized
+        /// Wallet screen was presented to the user
+        case ready
     }
 
-    // MARK: - Setups
+    let networkName: String
+    let configationState: WalletConfigurationState
+    let isCloudBackupEnabled: Bool
+    let hasVerifiedSeedPhrase: Bool
 
-    private static func setupNetwork() -> TariNetwork {
-        guard let selectedNetworkName = GroupUserDefaults.selectedNetworkName, let network = TariNetwork.all.first(where: { $0.name == selectedNetworkName }) else {
-            GroupUserDefaults.selectedNetworkName = defaultNetwork.name
-            return defaultNetwork
-        }
-        return network
-    }
+    static func == (lhs: Self, rhs: Self) -> Bool { lhs.networkName == rhs.networkName }
+}
 
-    private func setupFeedbacks() {
-        $selectedNetwork
-            .sink { GroupUserDefaults.selectedNetworkName = $0.name }
-            .store(in: &cancelables)
-    }
-
-    // MARK: - Actions
-
-    func removeSelectedNetworkSettings() {
-        GroupUserDefaults.networksSettings?.removeAll { $0.name == GroupUserDefaults.selectedNetworkName }
-        GroupUserDefaults.selectedNetworkName = nil
-    }
+extension WalletSettings {
+    func update(configationState: WalletConfigurationState) -> Self { Self(networkName: networkName, configationState: configationState, isCloudBackupEnabled: isCloudBackupEnabled, hasVerifiedSeedPhrase: hasVerifiedSeedPhrase) }
+    func update(isCloudBackupEnabled: Bool) -> Self { Self(networkName: networkName, configationState: configationState, isCloudBackupEnabled: isCloudBackupEnabled, hasVerifiedSeedPhrase: hasVerifiedSeedPhrase) }
+    func update(hasVerifiedSeedPhrase: Bool) -> Self { Self(networkName: networkName, configationState: configationState, isCloudBackupEnabled: isCloudBackupEnabled, hasVerifiedSeedPhrase: hasVerifiedSeedPhrase) }
 }

--- a/MobileWallet/TariLib/Wrappers/Utils/Settings/Wallet/WalletSettingsManager.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/Settings/Wallet/WalletSettingsManager.swift
@@ -1,0 +1,81 @@
+//  WalletSettingsManager.swift
+
+/*
+	Package MobileWallet
+	Created by Adrian Truszczynski on 03/10/2021
+	Using Swift 5.0
+	Running on macOS 12.0
+
+	Copyright 2019 The Tari Project
+
+	Redistribution and use in source and binary forms, with or
+	without modification, are permitted provided that the
+	following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above
+	copyright notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	3. Neither the name of the copyright holder nor the names of
+	its contributors may be used to endorse or promote products
+	derived from this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+	CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+	CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+	OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+final class WalletSettingsManager {
+
+    private var settings: WalletSettings {
+
+        guard let networkName = GroupUserDefaults.selectedNetworkName else {
+            return WalletSettings(networkName: "", configationState: .notConfigured, isCloudBackupEnabled: false, hasVerifiedSeedPhrase: false)
+        }
+
+        guard let existingSettings = GroupUserDefaults.walletSettings?.first(where: { $0.networkName == networkName }) else {
+            var settings = GroupUserDefaults.walletSettings ?? []
+            let newSettings = WalletSettings(networkName: networkName, configationState: .notConfigured, isCloudBackupEnabled: false, hasVerifiedSeedPhrase: false)
+            settings.append(newSettings)
+            GroupUserDefaults.walletSettings = settings
+            return newSettings
+        }
+
+        return existingSettings
+    }
+
+    var configationState: WalletSettings.WalletConfigurationState {
+        get { settings.configationState }
+        set { update(settings: settings.update(configationState: newValue)) }
+    }
+
+    var isCloudBackupEnabled: Bool {
+        get { settings.isCloudBackupEnabled }
+        set { update(settings: settings.update(isCloudBackupEnabled: newValue)) }
+    }
+
+    var hasVerifiedSeedPhrase: Bool {
+        get { settings.hasVerifiedSeedPhrase }
+        set { update(settings: settings.update(hasVerifiedSeedPhrase: newValue)) }
+    }
+
+    private func update(settings: WalletSettings) {
+        var allSettings = GroupUserDefaults.walletSettings ?? []
+        allSettings.removeAll { $0 == settings }
+        allSettings.append(settings)
+        GroupUserDefaults.walletSettings = allSettings
+    }
+}

--- a/MobileWallet/TariLib/Wrappers/WalletTxs.swift
+++ b/MobileWallet/TariLib/Wrappers/WalletTxs.swift
@@ -55,7 +55,7 @@ extension Wallet {
     func cancelledTransactions() throws -> CompletedTxs {
         var errorCode: Int32 = -1
         let result = withUnsafeMutablePointer(to: &errorCode) {
-            CompletedTxs(completedTxsPointer: wallet_get_completed_transactions(pointer, $0), isCancelled: true)
+            CompletedTxs(completedTxsPointer: wallet_get_cancelled_transactions(pointer, $0), isCancelled: true)
         }
 
         guard errorCode == 0 else { throw WalletErrors.generic(errorCode) }

--- a/MobileWallet/en.lproj/Localizable.strings
+++ b/MobileWallet/en.lproj/Localizable.strings
@@ -162,7 +162,8 @@
 "splash.disclaimer.param.privacy_policy" = "Privacy Policy";
 "splash.disclaimer.param.user_agreement" = "User Agreement";
 "splash.title" = "Private by default. Useful by design.";
-"splash.create_wallet" = "Create Your Wallet";
+"splash.button.create_wallet" = "Create Your Wallet";
+"splash.button.open_wallet" = "Open Existing Wallet";
 "splash.button.select_network" = "Selected Network: %@";
 "splash.restore_wallet" = "Restore an Existing wallet";
 "splash.wallet_error.title" = "Unable to start wallet";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fixed issue with "token input field" on "restore wallet from the seed words" screen. Now, business logic will include last word in the input field to the seed words before it's start to restore the wallet.
- Fixed issue with empty network status bubble. Now it will show an initial status (before any change).
- Moved predefined base node sorting from SelectBaseNodeModel to TariNetwork
- Fixed UI and logic issues related to network switching
- Fixed issue with deeplink parser. Now user will be able to use deeplinks from notifications and QR codes.
- Fixed issue with redundant "cancelled" transaction for each "completed" transaction.
- Synchronised UI related actions on the home screen with main/UI thread.
- Moved "hasVerifiedSeedPhrase" used default setting to WalletSettings struct. Now this value will be correlated with selected network.
- Moved "isCloudBackupEnabled" from NetworkSettings to WalletSettings
- Created "WalletConfigurationState" to better handle onboarding flow. New variable is stored in WalletSettings.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
