### PR TITLE
- 0.9.0.1 - Hotfix

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -14,6 +14,6 @@ target 'MobileWallet' do
   pod 'Giphy', '2.0.0'
   pod 'IPtProxy', '~> 0.1.0'
   pod 'OpenSSL-Universal'
-  pod 'YatLib', '0.2.3'
+  pod 'YatLib', '0.2.4'
   pod 'TariCommon', '0.1.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -38,7 +38,7 @@ PODS:
   - SwiftKeychainWrapper (3.4.0)
   - SwiftLint (0.43.1)
   - TariCommon (0.1.0)
-  - YatLib (0.2.3):
+  - YatLib (0.2.4):
     - TariCommon (~> 0.1.0)
   - ZIPFoundation (0.9.12)
 
@@ -55,7 +55,7 @@ DEPENDENCIES:
   - SwiftKeychainWrapper (= 3.4.0)
   - SwiftLint
   - TariCommon (= 0.1.0)
-  - YatLib (= 0.2.3)
+  - YatLib (= 0.2.4)
   - ZIPFoundation (~> 0.9)
 
 SPEC REPOS:
@@ -107,9 +107,9 @@ SPEC CHECKSUMS:
   SwiftKeychainWrapper: 6fc49fbf7d4a6b0772917acb0e53a1639f6078d6
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   TariCommon: c524aaedbe01cd2780ac0c97706d2bd99daf10d7
-  YatLib: 97f96e1312970aff16355cb6f450be35aaba8140
+  YatLib: a49fad3e2cb3939b7f9df833bf56e36ec29f0f3c
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: b631c3b099fe62d0e00717ca43e9e1a8b3b6e62d
+PODFILE CHECKSUM: 1e46557b85ed744d1b2f250356c87992e0a39017
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
- Fixed issue with Yat's deeplink handling by updating YatLib to the newest version
- Added persistence to `balanceUpdate` event. Now the listener will be retained until the view object will be deallocated.
- Improved the way how the total balance is updated. Now, app will take value directly from FFI library instead of using local cache.
