### PR TITLE
Crash during iCloud Backup

### DIFF
--- a/MobileWallet/Backup/ICloudBackup.swift
+++ b/MobileWallet/Backup/ICloudBackup.swift
@@ -174,7 +174,7 @@ class ICloudBackup: NSObject {
         try? startObserveReachability()
 
         if FileManager.default.ubiquityIdentityToken == nil {
-            iCloudBackupsIsOn = false
+            TariSettings.shared.walletSettings.isCloudBackupEnabled = false
         }
     }
 


### PR DESCRIPTION
- Removed circular reference call between ICloudBackup and BackupScheduler

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
