### PR TITLE
Missing copy message

### DIFF
--- a/MobileWallet/UIElements/EmojiIdView.swift
+++ b/MobileWallet/UIElements/EmojiIdView.swift
@@ -52,8 +52,8 @@ final class EmojiIdView: UIView {
 
     var expanded: Bool = false
     var blackoutWhileExpanded = true
-    var copyText: String = ""
-    var tooltipText: String?
+    var copyText: String = localized("emoji.copy")
+    var tooltipText: String? = localized("profile_view.error.qr_code.description.with_param", arguments: NetworkManager.shared.selectedNetwork.tickerSymbol)
     
     var tapToExpand: ((_ expanded: Bool) -> Void)?
     private var initialWidth: CGFloat = CGFloat(172)


### PR DESCRIPTION
- Fixed issue with empty copy "bubble". Now EmojiIdView will show default text and tooltip when any other wasn't set.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
