### PR TITLE
App crash on the transition from seed words list to the verification screen on iOS 14

### DIFF
--- a/MobileWallet/Screens/Settings/BackUpSettings/VerifySeedWords/VerifySeedWordsModel.swift
+++ b/MobileWallet/Screens/Settings/BackUpSettings/VerifySeedWords/VerifySeedWordsModel.swift
@@ -66,11 +66,17 @@ final class VerifySeedWordsModel {
     init(inputData: InputData) {
         self.inputData = inputData
         
+        if #available(iOS 15, *) {
+            fetchData()
+        }
+        
+        setupCallbacks()
+    }
+    
+    func fetchData() {
         availableTokenModels = inputData.seedWords
             .sorted()
             .map { SeedWordModel(id: UUID(), title: $0, state: .valid, visualTrait: .none) }
-        
-        setupCallbacks()
     }
     
     // MARK: - Setups

--- a/MobileWallet/Screens/Settings/BackUpSettings/VerifySeedWords/VerifySeedWordsViewController.swift
+++ b/MobileWallet/Screens/Settings/BackUpSettings/VerifySeedWords/VerifySeedWordsViewController.swift
@@ -72,6 +72,13 @@ final class VerifySeedWordsViewController: UIViewController {
         setupCallbacks()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if #available(iOS 15, *) {} else {
+            model.fetchData()
+        }
+    }
+    
     // MARK: - Setups
     
     private func setupCallbacks() {


### PR DESCRIPTION
- Created created separated data propagation flows for iOS 13-14 and iOS 15+ to prevent app from crashing on VerifySeedWordsViewController

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [ ] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
