### PR TITLE
The user should be able to select the base node before the wallet restoration process.

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		3A87C3B527A94086007A553F /* CoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A87C3B427A94086007A553F /* CoreError.swift */; };
 		3A87C3B727A9409E007A553F /* WalletError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A87C3B627A9409E007A553F /* WalletError.swift */; };
 		3A87C3B927A96423007A553F /* ErrorMessageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A87C3B827A96423007A553F /* ErrorMessageManagerTests.swift */; };
+		3A8826C527F1B8320037F779 /* UICollectionViewDiffableDataSource+Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8826C427F1B8320037F779 /* UICollectionViewDiffableDataSource+Animation.swift */; };
 		3A96B9452733E9A90040E59F /* TokensToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A96B9442733E9A90040E59F /* TokensToolbar.swift */; };
 		3A983A5A27C62A3900F0AB61 /* VerifySeedWordsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A983A5927C62A3900F0AB61 /* VerifySeedWordsViewController.swift */; };
 		3A983A5C27C62A5700F0AB61 /* VerifySeedWordsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A983A5B27C62A5700F0AB61 /* VerifySeedWordsView.swift */; };
@@ -542,6 +543,7 @@
 		3A87C3B427A94086007A553F /* CoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreError.swift; sourceTree = "<group>"; };
 		3A87C3B627A9409E007A553F /* WalletError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletError.swift; sourceTree = "<group>"; };
 		3A87C3B827A96423007A553F /* ErrorMessageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageManagerTests.swift; sourceTree = "<group>"; };
+		3A8826C427F1B8320037F779 /* UICollectionViewDiffableDataSource+Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewDiffableDataSource+Animation.swift"; sourceTree = "<group>"; };
 		3A96B9442733E9A90040E59F /* TokensToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokensToolbar.swift; sourceTree = "<group>"; };
 		3A983A5927C62A3900F0AB61 /* VerifySeedWordsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifySeedWordsViewController.swift; sourceTree = "<group>"; };
 		3A983A5B27C62A5700F0AB61 /* VerifySeedWordsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifySeedWordsView.swift; sourceTree = "<group>"; };
@@ -750,6 +752,7 @@
 				3AF167432782FD7C0019A30E /* Wallet+Conveniences.swift */,
 				3A420596279803DF00A8D49C /* CharacterSet+CustomSets.swift */,
 				3A4BF7CD27B5712900CA499D /* Result+Void.swift */,
+				3A8826C427F1B8320037F779 /* UICollectionViewDiffableDataSource+Animation.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2277,6 +2280,7 @@
 				37ABB69024781CE800F08163 /* UILabel.swift in Sources */,
 				3AA2DD962796F72100DC3CF7 /* QRCodePresentationView.swift in Sources */,
 				3AFAC360271C6B4D008AA842 /* ContactAvatarView.swift in Sources */,
+				3A8826C527F1B8320037F779 /* UICollectionViewDiffableDataSource+Animation.swift in Sources */,
 				379D27AF244EF25000F1AD98 /* NavigationBarWithSubtitle.swift in Sources */,
 				3A5E881E26BA9CF10029BB8B /* HomeView.swift in Sources */,
 				3ACFA42B278EC9F200EBED98 /* ProfileModel.swift in Sources */,

--- a/MobileWallet/Common/Extensions/UICollectionViewDiffableDataSource+Animation.swift
+++ b/MobileWallet/Common/Extensions/UICollectionViewDiffableDataSource+Animation.swift
@@ -1,0 +1,51 @@
+//  UICollectionViewDiffableDataSource+Animation.swift
+	
+/*
+	Package MobileWallet
+	Created by Adrian Truszczynski on 28/03/2022
+	Using Swift 5.0
+	Running on macOS 12.3
+
+	Copyright 2019 The Tari Project
+
+	Redistribution and use in source and binary forms, with or
+	without modification, are permitted provided that the
+	following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above
+	copyright notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	3. Neither the name of the copyright holder nor the names of
+	its contributors may be used to endorse or promote products
+	derived from this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+	CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+	CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+	OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import UIKit
+
+extension UICollectionViewDiffableDataSource {
+
+    ///  Delayed snapshot fixes issue with animated self-sizing cells. By delaying the process, the collection view will not animate resizing from the estimated size to target size on every update.
+    func apply(delayedSnapshot: UIKit.NSDiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>, animatingDifferences: Bool, completion: (() -> Void)?) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+            self.apply(delayedSnapshot, animatingDifferences: animatingDifferences, completion: completion)
+        }
+    }
+}

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/RestoreWalletFromSeedsViewController.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/RestoreWalletFromSeedsViewController.swift
@@ -84,16 +84,7 @@ final class RestoreWalletFromSeedsViewController: SettingsParentViewController, 
     }
 
     private func setupFeedbacks() {
-        
-        mainView.tokenView.$inputText
-            .assign(to: \.inputText, on: model)
-            .store(in: &cancelables)
-
-        mainView.onTapOnSubmitButton = { [weak self] in
-            _ = self?.mainView.resignFirstResponder()
-            self?.model.startRestoringWallet()
-        }
-
+    
         model.viewModel.$isEmptyWalletCreated
             .sink { [weak self] isEmptyWalletCreated in
                 guard isEmptyWalletCreated else { return }
@@ -127,7 +118,13 @@ final class RestoreWalletFromSeedsViewController: SettingsParentViewController, 
             .store(in: &cancelables)
         
         model.viewModel.$seedWordModels
+            .receive(on: RunLoop.main)
             .assign(to: \.seedWords, on: mainView.tokenView)
+            .store(in: &cancelables)
+        
+        mainView.tokenView.$inputText
+            .receive(on: RunLoop.main)
+            .assign(to: \.inputText, on: model)
             .store(in: &cancelables)
         
         mainView.tokenView.onSelectSeedWord = { [weak self] in
@@ -141,6 +138,15 @@ final class RestoreWalletFromSeedsViewController: SettingsParentViewController, 
         mainView.tokenView.onEndEditing = { [weak self] in
             self?.model.handleEndEditing()
         }
+
+        mainView.selectBaseNodeButton.onTap =  { [weak self] in
+            self?.moveToSelectBaseNodeScene()
+        }
+        
+        mainView.submitButton.onTap = { [weak self] in
+            _ = self?.mainView.resignFirstResponder()
+            self?.model.startRestoringWallet()
+        }
     }
 
     // MARK: - Actions
@@ -150,12 +156,14 @@ final class RestoreWalletFromSeedsViewController: SettingsParentViewController, 
         let overlay = RestoreWalletFromSeedsProgressViewController()
 
         overlay.onSuccess = { [weak self, weak overlay] in
-            overlay?.dismiss(animated: true) {
-
-            }
+            overlay?.dismiss(animated: true)
             self?.navigationController?.popToRootViewController(animated: true)
         }
 
         show(overlay: overlay)
+    }
+    
+    private func moveToSelectBaseNodeScene() {
+        navigationController?.pushViewController(SelectBaseNodeViewController(), animated: true)
     }
 }

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/RestoreWalletFromSeedsView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/RestoreWalletFromSeedsView.swift
@@ -57,15 +57,18 @@ final class RestoreWalletFromSeedsView: KeyboardAvoidingContentView {
 
     @View var tokenView = TokenCollectionView()
 
-    @View private var submitButton: ActionButton = {
+    @View private(set) var selectBaseNodeButton: TextButton = {
+        let view = TextButton()
+        view.setVariation(.secondary)
+        view.setTitle(localized("restore_from_seed_words.button.select_base_node"), for: .normal)
+        return view
+    }()
+    
+    @View private(set) var submitButton: ActionButton = {
         let view = ActionButton()
         view.setTitle(localized("restore_from_seed_words.button.submit"), for: .normal)
         return view
     }()
-
-    // MARK: - Properties
-
-    var onTapOnSubmitButton: (() -> Void)?
 
     // MARK: - Initializers
 
@@ -73,7 +76,6 @@ final class RestoreWalletFromSeedsView: KeyboardAvoidingContentView {
         super.init(frame: .zero)
         setupViews()
         setupConstraints()
-        setupFeedbacks()
     }
 
     required init?(coder: NSCoder) {
@@ -88,7 +90,7 @@ final class RestoreWalletFromSeedsView: KeyboardAvoidingContentView {
 
     private func setupConstraints() {
 
-        [descriptionLabel, tokenView, submitButton].forEach(contentView.addSubview)
+        [descriptionLabel, tokenView, selectBaseNodeButton, submitButton].forEach(contentView.addSubview)
 
         let constraints = [
             descriptionLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20.0),
@@ -98,7 +100,10 @@ final class RestoreWalletFromSeedsView: KeyboardAvoidingContentView {
             tokenView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 25.0),
             tokenView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -25.0),
             tokenView.heightAnchor.constraint(equalToConstant: 272.0),
-            submitButton.topAnchor.constraint(greaterThanOrEqualTo: tokenView.bottomAnchor, constant: 20.0),
+            selectBaseNodeButton.topAnchor.constraint(greaterThanOrEqualTo: tokenView.bottomAnchor, constant: 20.0),
+            selectBaseNodeButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 25.0),
+            selectBaseNodeButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -25.0),
+            submitButton.topAnchor.constraint(equalTo: selectBaseNodeButton.bottomAnchor, constant: 20.0),
             submitButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 25.0),
             submitButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -25.0),
             submitButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -28.0)
@@ -107,20 +112,10 @@ final class RestoreWalletFromSeedsView: KeyboardAvoidingContentView {
         NSLayoutConstraint.activate(constraints)
     }
 
-    private func setupFeedbacks() {
-        submitButton.addTarget(self, action: #selector(onTapOnSubmitButtonAction), for: .touchUpInside)
-    }
-
     // MARK: - Actions
 
     func update(buttonIsEnabledStatus: Bool) {
         submitButton.variation = buttonIsEnabledStatus ? .normal : .disabled
-    }
-
-    // MARK: - Action Targets
-
-    @objc private func onTapOnSubmitButtonAction() {
-        onTapOnSubmitButton?()
     }
 
     // MARK: - First Responder

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenCollectionView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenCollectionView.swift
@@ -215,7 +215,7 @@ final class TokenCollectionView: UIView {
         var snapshot = NSDiffableDataSourceSnapshot<Int, SeedWordModel>()
         snapshot.appendSections([0])
         snapshot.appendItems(seedWords)
-        dataSource?.apply(snapshot, animatingDifferences: true) { [weak self] in
+        dataSource?.apply(delayedSnapshot: snapshot, animatingDifferences: true) { [weak self] in
             guard let self = self else { return }
             self.collectionView.scrollToBottom(animated: true)
             self.heightConstraint?.constant = self.collectionView.contentSize.height

--- a/MobileWallet/en.lproj/Localizable.strings
+++ b/MobileWallet/en.lproj/Localizable.strings
@@ -525,6 +525,7 @@
 
 /* Restore Wallet From Seed Words */
 "restore_from_seed_words.label.description" = "Enter your seed phrase to restore your wallet";
+"restore_from_seed_words.button.select_base_node" = "Select base node";
 "restore_from_seed_words.button.submit" = "Restore Wallet";
 "restore_from_seed_words.autocompletion_toolbar.label.start_typing" = "Start typing to see suggestions";
 "restore_from_seed_words.autocompletion_toolbar.label.no_suggestions" = "There are no suggestions for the phrase";


### PR DESCRIPTION
- Added "select base node" button to the RestoreWalletFromSeedsView. User can now use it to select the base node that will be used for wallet recovery.
- Fixed UI issue related to self-siding UICollectionViewCells.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
