### PR TITLE
Float to Int conversion in MicroTari doesn't work correctly.

### DIFF
--- a/MobileWallet/TariLib/Wrappers/Utils/MicroTari.swift
+++ b/MobileWallet/TariLib/Wrappers/Utils/MicroTari.swift
@@ -163,10 +163,8 @@ extension MicroTari {
     }
 
     public static func checkValue(_ value: NSNumber) -> Bool {
-        guard let _ = UInt64(exactly: value.floatValue * Float(MicroTari.conversion)) else {
-            return false
-        }
-        return true
+        let convertedValue = value.decimalValue * Decimal(MicroTari.conversion)
+        return convertedValue.isLessThanOrEqualTo(Decimal(UInt64.max))
     }
 
     public static func checkValue(_ value: String) -> Bool {


### PR DESCRIPTION
Fixed issue related to the floating-point conversion. Now, MicroTari's internal verification logic will convert Float to UInt64 (and vice versa) correctly.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- What feature is it related to? Why is this change required? What problem does it solve?-->
<!--- If it fixes an open issue or closes a feature ticket, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots and/or video clip
<!--- Only applicable if this PR has UI changes -->
<!--- Please upload screenshots from simulator of all device screen sizes -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I have tested this on multiple simulator devices with different screensizes.
* [ ] I'm merging against the `development` branch.
* [ ] Commits have been squashed into one commit with a descriptive commit message
* [ ] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
