### PR TITLE
UTXOs Wallet - Dimmed Tiles/Cells in selection mode

### DIFF
--- a/MobileWallet/Screens/Home/UTXOs Wallet/Views/UTXOTileView.swift
+++ b/MobileWallet/Screens/Home/UTXOs Wallet/Views/UTXOTileView.swift
@@ -216,9 +216,14 @@ final class UTXOTileView: UICollectionViewCell {
     }
     
     func updateTickBox(isVisible: Bool) {
-        
-        UIView.animate(withDuration: 0.1) {
+        UIView.animate(withDuration: 0.3) {
             self.tickView.alpha = isVisible ? 1.0 : 0.0
+        }
+    }
+    
+    func updateBackground(isSemitransparent: Bool) {
+        UIView.animate(withDuration: 0.3) {
+            self.contentView.alpha = isSemitransparent ? 0.6 : 1.0
         }
     }
     

--- a/MobileWallet/Screens/Home/UTXOs Wallet/Views/UTXOsWalletTextListView.swift
+++ b/MobileWallet/Screens/Home/UTXOs Wallet/Views/UTXOsWalletTextListView.swift
@@ -125,7 +125,7 @@ final class UTXOsWalletTextListView: UIView {
             let cell = tableView.dequeueReusableCell(type: UTXOsWalletTextListViewCell.self, indexPath: indexPath)
             
             cell.update(model: model)
-            cell.updateTickBox(isVisible: model.isSelectable && self.isEditingEnabled, animated: false)
+            cell.update(isSelectable: model.isSelectable, isEditingEnabled: self.isEditingEnabled, animated: false)
             cell.isTickSelected = self.selectedElements.contains(model.id)
             
             return cell
@@ -158,7 +158,7 @@ final class UTXOsWalletTextListView: UIView {
             .compactMap { $0 as? UTXOsWalletTextListViewCell }
             .forEach { cell in
                 guard let isSelectable = models.first(where: { $0.id == cell.elementID })?.isSelectable else { return }
-                cell.updateTickBox(isVisible: isSelectable && isEditing, animated: true)
+                cell.update(isSelectable: isSelectable, isEditingEnabled: isEditing, animated: true)
             }
     }
 }
@@ -171,5 +171,13 @@ extension UTXOsWalletTextListView: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         onTapOnCell?(models[indexPath.row].id)
+    }
+}
+
+private extension UTXOsWalletTextListViewCell {
+    
+    func update(isSelectable: Bool, isEditingEnabled: Bool, animated: Bool) {
+        updateTickBox(isVisible: isSelectable && isEditingEnabled, animated: animated)
+        updateBackground(isSemitransparent: !isSelectable && isEditingEnabled, animated: animated)
     }
 }

--- a/MobileWallet/Screens/Home/UTXOs Wallet/Views/UTXOsWalletTextListViewCell.swift
+++ b/MobileWallet/Screens/Home/UTXOs Wallet/Views/UTXOsWalletTextListViewCell.swift
@@ -182,6 +182,13 @@ final class UTXOsWalletTextListViewCell: UITableViewCell {
         }
     }
     
+    func updateBackground(isSemitransparent: Bool, animated: Bool) {
+        
+        UIView.animate(withDuration: animated ? 0.3 : 0.0) {
+            self.contentView.alpha = isSemitransparent ? 0.6 : 1.0
+        }
+    }
+    
     private func update(selectionState: Bool) {
         tickView.isSelected = selectionState
     }

--- a/MobileWallet/Screens/Home/UTXOs Wallet/Views/UTXOsWalletTileListView.swift
+++ b/MobileWallet/Screens/Home/UTXOs Wallet/Views/UTXOsWalletTileListView.swift
@@ -129,7 +129,7 @@ final class UTXOsWalletTileListView: UIView {
             guard let self = self else { return cell }
             
             cell.update(model: model)
-            cell.updateTickBox(isVisible: model.isSelectable && self.isEditingEnabled)
+            cell.update(isSelectable: model.isSelectable, isEditingEnabled: self.isEditingEnabled)
             cell.isTickSelected = self.selectedElements.contains(model.uuid)
             
             cell.onTap = { [weak self] uuid in
@@ -171,7 +171,7 @@ final class UTXOsWalletTileListView: UIView {
             .compactMap { $0 as? UTXOTileView }
             .forEach { tile in
                 guard let model = models.first(where: { $0.uuid == tile.elementID }) else { return }
-                tile.updateTickBox(isVisible: model.isSelectable && isEditing)
+                tile.update(isSelectable: model.isSelectable, isEditingEnabled: isEditing)
             }
     }
     
@@ -191,5 +191,13 @@ extension UTXOsWalletTileListView: UICollectionViewDelegate {
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         verticalContentOffset = scrollView.contentOffset.y
+    }
+}
+
+private extension UTXOTileView {
+    
+    func update(isSelectable: Bool, isEditingEnabled: Bool) {
+        updateTickBox(isVisible: isSelectable && isEditingEnabled)
+        updateBackground(isSemitransparent: !isSelectable && isEditingEnabled)
     }
 }


### PR DESCRIPTION
- Tiles and cells on UTXOs Wallet scene no will be semitransparent when they are pending/unconfirmed and selection mode is turned on.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [ ] Functionality bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
