### PR TITLE
Value underflow on calculating transaction fee

### DIFF
--- a/MobileWallet/Screens/Send/AddAmount/TransactionFeesManager.swift
+++ b/MobileWallet/Screens/Send/AddAmount/TransactionFeesManager.swift
@@ -200,7 +200,8 @@ final class TransactionFeesManager {
     
     private func calculateFees(wallet: Wallet, amount: MicroTari, feesPerGram: FeeOptions) throws -> FeeOptions {
         
-        let maxAmountRaw = try wallet.totalBalance.rawValue - rawMaxAmountBuffer
+        let totalBalance = try wallet.totalBalance.rawValue
+        let maxAmountRaw = totalBalance > rawMaxAmountBuffer ? totalBalance - rawMaxAmountBuffer : 0
         let amountRaw = min(amount.rawValue, maxAmountRaw)
         let amount = MicroTari(amountRaw)
         


### PR DESCRIPTION
- Fixed issue realated to UInt64 underflow. Now, value used to calculate transaction fee can't be negative.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
