### PR TITLE
Build Script Fix

### DIFF
--- a/update_dependencies.sh
+++ b/update_dependencies.sh
@@ -46,4 +46,5 @@ echo "\n\n***Updating Property Lists***"
 CONSTS_PLIST_PATH="./MobileWallet/Constants.plist"
 FFI_VERSION_KEY="FFI Version"
 
+plutil -create xml1 $CONSTS_PLIST_PATH
 plutil -replace "$FFI_VERSION_KEY" -string $FFI_VERSION $CONSTS_PLIST_PATH


### PR DESCRIPTION
- fixed issue with update_dependencies.sh when Constants.plist file doesn't exist

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] UI fix (non-breaking change which fixes a UI issue)
* [x] Functionality bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I have tested this on multiple simulator devices with different screensizes.
* [x] I'm merging against the `development` branch.
* [x] Commits have been squashed into one commit with a descriptive commit message
* [x] I ran all tests before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added/changed tests to cover my changes if not UI changes.
