### PR TITLE
FFI Update

### DIFF
--- a/MobileWallet/Backup/Manager/BackupFilesManager.swift
+++ b/MobileWallet/Backup/Manager/BackupFilesManager.swift
@@ -147,8 +147,6 @@ enum BackupFilesManager {
         try model.utxos
             .map { try UnblindedOutput(json: $0) }
             .forEach { _ = try Tari.shared.unspentOutputsService.store(unspentOutput: $0, sourceAddress: sourceAddress, message: localized("backup.cloud.partial.recovery_message")) }
-
-        try MigrationManager.updateWalletVersion()
     }
 
     private static func recoverFullBackup(backupURL: URL, password: String) async throws {

--- a/MobileWallet/Common/Managers/MigrationManager.swift
+++ b/MobileWallet/Common/Managers/MigrationManager.swift
@@ -46,22 +46,7 @@ enum MigrationManager {
 
     // MARK: - Properties
 
-    private static let minValidVersion = "0.48.0"
-
-    private static var currentWalletVersion: String {
-
-        get throws {
-            guard
-                let path = Bundle.main.path(forResource: "Constants", ofType: "plist"),
-                let data = FileManager.default.contents(atPath: path),
-                let dictionary = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: String],
-                let value = dictionary["FFI Version"]
-            else {
-                throw MigrationError.noCurrentWalletVersion
-            }
-            return value
-        }
-    }
+    private static let minValidVersion = "0.49.0-pre.4"
 
     // MARK: - Actions
 
@@ -77,21 +62,16 @@ enum MigrationManager {
         }
     }
 
-    static func updateWalletVersion() throws {
-        try Tari.shared.keyValues.set(key: .version, value: currentWalletVersion)
-    }
-
     private static func isWalletHasValidVersion() -> Bool {
 
-        let walletVersion: String
-
-        do {
-            walletVersion = try Tari.shared.keyValues.value(key: .version)
-        } catch {
+        if let version = try? Tari.shared.walletVersion {
+            let isValid = VersionValidator.compare(version, isHigherOrEqualTo: minValidVersion)
+            Logger.log(message: "Min. Valid Wallet Version: \(minValidVersion), Local Wallet Version: \(version), isValid: \(isValid)", domain: .general, level: .info)
+            return isValid
+        } else {
+            Logger.log(message: "Unable to get wallet version", domain: .general, level: .info)
             return false
         }
-
-        return VersionValidator.compare(walletVersion, isHigherOrEqualTo: minValidVersion)
     }
 
     private static func showPopUp(completion: @escaping (Bool) -> Void) {

--- a/MobileWallet/Screens/AppEntry/Splash/SplashViewModel.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/SplashViewModel.swift
@@ -133,7 +133,6 @@ final class SplashViewModel {
             do {
                 status = StatusModel(status: .working, statusRepresentation: .content)
                 try await connectToWallet(isWalletConnected: false)
-                try MigrationManager.updateWalletVersion()
                 status = StatusModel(status: .success, statusRepresentation: .content)
             } catch {
                 handle(error: error)
@@ -149,13 +148,13 @@ final class SplashViewModel {
                 let statusRepresentation = status?.statusRepresentation ?? .content
                 status = StatusModel(status: .working, statusRepresentation: statusRepresentation)
 
-                try await connectToWallet(isWalletConnected: isWalletConnected)
-                isWalletConnected = false
-
                 guard await validateWallet() else {
                     self.deleteWallet()
                     return
                 }
+
+                try await connectToWallet(isWalletConnected: isWalletConnected)
+                isWalletConnected = false
 
                 status = StatusModel(status: .success, statusRepresentation: statusRepresentation)
             } catch {

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/RestoreWalletFromSeedsViewController.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/RestoreWalletFromSeedsViewController.swift
@@ -156,7 +156,6 @@ final class RestoreWalletFromSeedsViewController: SettingsParentViewController, 
         let overlay = SeedWordsRecoveryProgressViewController()
 
         overlay.onSuccess = {
-            try? MigrationManager.updateWalletVersion()
             AppRouter.transitionToSplashScreen(isWalletConnected: true)
         }
 

--- a/MobileWallet/TariLib/Core/FFIWalletManager.swift
+++ b/MobileWallet/TariLib/Core/FFIWalletManager.swift
@@ -411,7 +411,15 @@ final class FFIWalletManager {
 
         guard errorCode == 0, let cString = result else { throw WalletError(code: errorCode) }
         return String(cString: cString)
+    }
 
+    func walletVersion(commsConfig: CommsConfig) throws -> String? {
+        var errorCode: Int32 = -1
+        let errorCodePointer = PointerHandler.pointer(for: &errorCode)
+        let result = wallet_get_last_version(commsConfig.pointer, errorCodePointer)
+        guard errorCode == 0 else { throw WalletError(code: errorCode) }
+        guard let result else { return nil }
+        return String(cString: result)
     }
 
     func seedWords() throws -> SeedWords {

--- a/MobileWallet/TariLib/Core/Services/TariKeyValueService.swift
+++ b/MobileWallet/TariLib/Core/Services/TariKeyValueService.swift
@@ -42,7 +42,6 @@ final class TariKeyValueService: CoreTariService {
 
     enum Key: String {
         case network = "SU7FM2O6Q3BU4XVN7HDD"
-        case version
     }
 
     func value(key: Key) throws -> String {

--- a/MobileWallet/TariLib/Core/Tari.swift
+++ b/MobileWallet/TariLib/Core/Tari.swift
@@ -89,6 +89,13 @@ final class Tari: MainServiceable {
         get throws { try walletManager.walletAddress() }
     }
 
+    var walletVersion: String? {
+        get throws {
+            let commsConfig = try makeCommsConfig()
+            return try walletManager.walletVersion(commsConfig: commsConfig)
+        }
+    }
+
     var logsURLs: [URL] {
         get throws {
             try FileManager.default.contentsOfDirectory(at: TariSettings.storageDirectory, includingPropertiesForKeys: nil)

--- a/UnitTests/VersionValidatorTests.swift
+++ b/UnitTests/VersionValidatorTests.swift
@@ -141,4 +141,95 @@ final class VersionValidatorTests: XCTestCase {
         let result = VersionValidator.compare(firstVersion, isHigherOrEqualTo: secondVersion)
         XCTAssertTrue(result)
     }
+
+    func testPreComponentFirstVersionIsHigher() {
+
+        let firstVersion = "1.23.4-pre.2"
+        let secondVersion = "1.23.4-pre.1"
+
+        let result = VersionValidator.compare(firstVersion, isHigherOrEqualTo: secondVersion)
+        XCTAssertTrue(result)
+    }
+
+    func testPreComponentSecondVersionIsHigher() {
+
+            let firstVersion = "1.23.4-pre.1"
+            let secondVersion = "1.23.4-pre.2"
+
+            let result = VersionValidator.compare(firstVersion, isHigherOrEqualTo: secondVersion)
+            XCTAssertFalse(result)
+    }
+
+    func testRcComponentFirstVersionIsHigher() {
+
+        let firstVersion = "1.23.4-rc.2"
+        let secondVersion = "1.23.4-rc.1"
+
+        let result = VersionValidator.compare(firstVersion, isHigherOrEqualTo: secondVersion)
+        XCTAssertTrue(result)
+    }
+
+    func testRcComponentSecondVersionIsHigher() {
+
+        let firstVersion = "1.23.4-rc.1"
+        let secondVersion = "1.23.4-rc.2"
+
+        let result = VersionValidator.compare(firstVersion, isHigherOrEqualTo: secondVersion)
+        XCTAssertFalse(result)
+    }
+
+
+    func testRcComponentIsHigherThanPreComponent() {
+
+        let firstVersion = "1.23.4-rc.1"
+        let secondVersion = "1.23.4-pre.1"
+
+        let result = VersionValidator.compare(firstVersion, isHigherOrEqualTo: secondVersion)
+        XCTAssertTrue(result)
+    }
+
+    func testNumberComponentIsHigherThanPreComponent() {
+
+        let firstVersion = "1.23.4"
+        let secondVersion = "1.23.4-pre.1"
+
+        let result = VersionValidator.compare(firstVersion, isHigherOrEqualTo: secondVersion)
+        XCTAssertTrue(result)
+    }
+
+    func testNumberComponentIsHigherThanRcComponent() {
+
+        let firstVersion = "1.23.4"
+        let secondVersion = "1.23.4-rc.1"
+
+        let result = VersionValidator.compare(firstVersion, isHigherOrEqualTo: secondVersion)
+        XCTAssertTrue(result)
+    }
+
+    func testPreComponentIsLowerThanRcComponent() {
+
+        let firstVersion = "1.23.4-pre.1"
+        let secondVersion = "1.23.4-rc.1"
+
+        let result = VersionValidator.compare(firstVersion, isHigherOrEqualTo: secondVersion)
+        XCTAssertFalse(result)
+    }
+
+    func testPreComponentIsLowerThanNumberComponent() {
+
+        let firstVersion = "1.23.4-pre.1"
+        let secondVersion = "1.23.4"
+
+        let result = VersionValidator.compare(firstVersion, isHigherOrEqualTo: secondVersion)
+        XCTAssertFalse(result)
+    }
+
+    func testRcComponentIsLowerThanNumberComponent() {
+
+        let firstVersion = "1.23.4-rc.1"
+        let secondVersion = "1.23.4"
+
+        let result = VersionValidator.compare(firstVersion, isHigherOrEqualTo: secondVersion)
+        XCTAssertFalse(result)
+    }
 }

--- a/dependencies.env
+++ b/dependencies.env
@@ -1,1 +1,1 @@
-FFI_VERSION="0.49.0-pre.3"
+FFI_VERSION="0.49.0-pre.4"

--- a/update_dependencies.sh
+++ b/update_dependencies.sh
@@ -61,13 +61,7 @@ if [ $API_KEY != null ]; then
   done
 fi
 
-# Constants.plist
-
-CONSTS_PLIST_PATH="./MobileWallet/Constants.plist"
-FFI_VERSION_KEY="FFI Version"
-
-plutil -create xml1 $CONSTS_PLIST_PATH
-plutil -replace "$FFI_VERSION_KEY" -string $FFI_VERSION $CONSTS_PLIST_PATH
+# Git Hooks
 
 echo "\n\n***Updating Git Hooks***"
 


### PR DESCRIPTION
- Updated FFI version to v0.49.0-pre.4
- Updated MigrationManager logic. Now, it will using data directly from FFI.
- Updated update_dependencies.sh script. Constants.plist generated by this script will be no longer needed.
- Removed unused code
- Added additional unit test to cover scenarios when FFI version have pre or rc component in version number.
