### PR TITLE
Bluetooth low energy - Data chunking

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -454,6 +454,7 @@
 		54AA5D5A298122B70031A396 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AA5D59298122B70031A396 /* OnboardingView.swift */; };
 		54AA5D5C2981267C0031A396 /* OnboardingPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AA5D5B2981267C0031A396 /* OnboardingPageViewController.swift */; };
 		54AA5D5E298126CA0031A396 /* OnboardingPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AA5D5D298126CA0031A396 /* OnboardingPageView.swift */; };
+		54AD5F662A420A9F00D223B8 /* Data+Utlis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AD5F652A420A9F00D223B8 /* Data+Utlis.swift */; };
 		54ADC0872A3856B50082C455 /* AddRecipientViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54ADC0852A3856B50082C455 /* AddRecipientViewController.swift */; };
 		54ADC0882A3856B50082C455 /* AddRecipientModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54ADC0862A3856B50082C455 /* AddRecipientModel.swift */; };
 		54ADC08B2A3857280082C455 /* AddRecipientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54ADC08A2A3857280082C455 /* AddRecipientView.swift */; };
@@ -1000,6 +1001,7 @@
 		54AA5D59298122B70031A396 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		54AA5D5B2981267C0031A396 /* OnboardingPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPageViewController.swift; sourceTree = "<group>"; };
 		54AA5D5D298126CA0031A396 /* OnboardingPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPageView.swift; sourceTree = "<group>"; };
+		54AD5F652A420A9F00D223B8 /* Data+Utlis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Utlis.swift"; sourceTree = "<group>"; };
 		54ADC0852A3856B50082C455 /* AddRecipientViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddRecipientViewController.swift; sourceTree = "<group>"; };
 		54ADC0862A3856B50082C455 /* AddRecipientModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddRecipientModel.swift; sourceTree = "<group>"; };
 		54ADC08A2A3857280082C455 /* AddRecipientView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddRecipientView.swift; sourceTree = "<group>"; };
@@ -1130,6 +1132,8 @@
 			children = (
 				376C62AD247574850091BB28 /* Animation+EnumInit.swift */,
 				3A2B956928648D860085BE21 /* CChar+Helpers.swift */,
+				541029052A406E4E0095F7CB /* CGFloat+Utils.swift */,
+				541029072A406E810095F7CB /* CGPoint+Utils.swift */,
 				3A420596279803DF00A8D49C /* CharacterSet+CustomSets.swift */,
 				00BBD808237D80C800EBF5E6 /* Date.swift */,
 				3A685425290AD04600032963 /* DateFormatter+Formats.swift */,
@@ -1147,6 +1151,7 @@
 				3A8826C427F1B8320037F779 /* UICollectionViewDiffableDataSource+Animation.swift */,
 				3AECD493284F46FD00D81C80 /* UIColor+Utils.swift */,
 				37E0B007249B700F00DFE315 /* UIFont+FontStyle.swift */,
+				54F306142A3B1E6300B5689D /* UIImage+Utils.swift */,
 				37ABB68F24781CE800F08163 /* UILabel.swift */,
 				54DD2E8529C37A7600C8C0D9 /* UINavigationController+Common.swift */,
 				54DEF9F22987DA8700C4B749 /* UIScreen+Tools.swift */,
@@ -1161,9 +1166,7 @@
 				54A6E9F3297F260800A60853 /* UIViewController+Common.swift */,
 				004277F623E0628A00AE7BD9 /* UIViewController+Content.swift */,
 				54621F8629E00E04000E9659 /* URL+Tools.swift */,
-				54F306142A3B1E6300B5689D /* UIImage+Utils.swift */,
-				541029052A406E4E0095F7CB /* CGFloat+Utils.swift */,
-				541029072A406E810095F7CB /* CGPoint+Utils.swift */,
+				54AD5F652A420A9F00D223B8 /* Data+Utlis.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3275,6 +3278,7 @@
 				543DF19C293F3DA90031EA70 /* BridgesConfigurationFooterView.swift in Sources */,
 				37765D2624A35BA20091AE2A /* AESEncryption.swift in Sources */,
 				3A82455627E1EE0D003B6B59 /* TransactionDetailsSectionView.swift in Sources */,
+				54AD5F662A420A9F00D223B8 /* Data+Utlis.swift in Sources */,
 				54ADC0882A3856B50082C455 /* AddRecipientModel.swift in Sources */,
 				54621F9029E01385000E9659 /* DeeplinkUnkeyedDecodingContainer.swift in Sources */,
 				3A7DAB9528FDB220002CC013 /* LogsListCell.swift in Sources */,

--- a/MobileWallet/Common/Extensions/Data+Utlis.swift
+++ b/MobileWallet/Common/Extensions/Data+Utlis.swift
@@ -1,0 +1,105 @@
+//  Data+Utlis.swift
+
+/*
+	Package MobileWallet
+	Created by Adrian Truszczyński on 20/06/2023
+	Using Swift 5.0
+	Running on macOS 13.4
+
+	Copyright 2019 The Tari Project
+
+	Redistribution and use in source and binary forms, with or
+	without modification, are permitted provided that the
+	following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above
+	copyright notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	3. Neither the name of the copyright holder nor the names of
+	its contributors may be used to endorse or promote products
+	derived from this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+	CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+	CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+	OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+extension Data {
+
+    enum BLEChunkType {
+        case normal
+        case last
+    }
+
+    var isBLEChunk: Bool { bleChunkType != nil }
+
+    var bleChunkType: BLEChunkType? {
+        switch last {
+        case 0:
+            return .last
+        case 1:
+            return .normal
+        default:
+            return nil
+        }
+    }
+
+    var bleDataChunks: [Data] {
+        let rawChunks = split(chunkSize: BLEConstants.chunkSize)
+        return rawChunks
+            .enumerated()
+            .map {
+                let controlByte: UInt8 = $0 == rawChunks.count - 1 ? 0 : 1
+                return $1.appending(byte: controlByte)
+            }
+    }
+
+    func split(chunkSize: Int) -> [Data] {
+
+        let lastIndex = count
+        var index = 0
+        var result: [Data] = []
+
+        repeat {
+            let nextIndex = Swift.min(index + chunkSize, lastIndex)
+            result.append(subdata(in: index..<nextIndex))
+            index = nextIndex
+        } while index != lastIndex
+
+        return result
+    }
+
+    func appending(byte: UInt8) -> Data {
+        var data = self
+        data.append(contentsOf: [byte])
+        return data
+    }
+}
+
+extension Array where Element == Data {
+
+    var dataFromBLEChunks: Data? {
+        guard first(where: { !$0.isBLEChunk }) == nil else { return nil }
+        return map { $0.dropLast() }
+            .reduce(into: Data()) { $0.append($1) }
+    }
+
+    var stringFromBLEChunks: String? {
+        guard let dataFromBLEChunks else { return nil }
+        return String(data: dataFromBLEChunks, encoding: .utf8)
+    }
+}

--- a/MobileWallet/Common/Managers/BLE/BLEConstants.swift
+++ b/MobileWallet/Common/Managers/BLE/BLEConstants.swift
@@ -41,6 +41,7 @@
 import CoreBluetooth
 
 enum BLEConstants {
+    static var chunkSize = 200
     static var contactBookService: BLEContactBookService.Type { BLEContactBookService.self }
 }
 

--- a/MobileWallet/Common/Pop-up/PopUpPresenter+CommonPopUps.swift
+++ b/MobileWallet/Common/Pop-up/PopUpPresenter+CommonPopUps.swift
@@ -287,14 +287,14 @@ private extension PopUpPresenter.BLEDialogType {
                 buttons: [makeCancelButtonModel()],
                 hapticType: .success
             )
-        case .scanForTransactionData:
+        case let .scanForTransactionData(onCancel):
             return BLEDialogModel(
                 image: .contactBook.bleDialog.icon,
                 imageTintColor: .purple,
                 title: localized("contact_book.popup.ble.transaction.scan.title"),
                 messageComponents: [StylizedLabel.StylizedText(text: localized("contact_book.popup.ble.transaction.scan.message"), style: .normal)],
                 tag: PopUpTag.bleScanTransactionDataDialog.rawValue,
-                buttons: [makeCancelButtonModel()],
+                buttons: [makeCancelButtonModel(callback: onCancel)],
                 hapticType: .none
             )
         case let .confirmTransactionData(receiverName, confirmationCallback, rejectCallback):

--- a/MobileWallet/en.lproj/Localizable.strings
+++ b/MobileWallet/en.lproj/Localizable.strings
@@ -727,6 +727,7 @@
 "error.ble.central.connection_error" = "Unable to establish a connection with the other device. Please make sure both devices are compatible and within range.";
 "error.ble.central.process_interrupted" = "The connection process was interrupted unexpectedly. Please try again later.";
 "error.ble.central.write_failed_characteristic_not_found" = "Unable to connect to the second device. Please check that the device is on and within range.";
+"error.ble.central.invalid_data" = "An error occurred while transferring data between devices. The data passed is invalid and cannot be read. Please try again.";
 
 /* Contacts Received PopUp */
 


### PR DESCRIPTION
All data that are used in BLE data transfer is now split into 200 bytes length data packets with an additional byte at the end that indicates the type of the packet. One indicates that there are more packets in the queue, and zero indicates that this is the last packet. The data is split by the sender, sent one by one, and joined back by the receiver.