### PR TITLE
Unknown contact(s) handling

### DIFF
--- a/MobileWallet/Screens/Contact Book/Managers/ContactsManager.swift
+++ b/MobileWallet/Screens/Contact Book/Managers/ContactsManager.swift
@@ -97,7 +97,7 @@ final class ContactsManager {
                     .map { $0.firstOrEmpty }
                     .joined()
             } else {
-                name = internalModel?.alias ?? internalModel?.emojiID.obfuscatedText ?? ""
+                name = internalModel?.alias ?? internalModel?.defaultAlias ?? internalModel?.emojiID.obfuscatedText ?? ""
                 nameComponents = [name]
                 avatar = internalModel?.emojiID.firstOrEmpty ?? ""
             }

--- a/MobileWallet/TariLib/Core/FFI/Keys/TariAddress.swift
+++ b/MobileWallet/TariLib/Core/FFI/Keys/TariAddress.swift
@@ -106,8 +106,17 @@ final class TariAddress {
 }
 
 extension TariAddress: Equatable {
+
     static func == (lhs: TariAddress, rhs: TariAddress) -> Bool {
         guard let leftHex = try? lhs.byteVector.hex, let rightHex = try? rhs.byteVector.hex else { return false }
         return leftHex == rightHex
+    }
+
+    var isUnknownUser: Bool {
+        get throws {
+            let rawAddress = try byteVector.hex
+            let rawEmojiID = rawAddress.dropLast(2)
+            return rawEmojiID.filter { $0 == "0" }.count == 64
+        }
     }
 }

--- a/MobileWallet/en.lproj/Localizable.strings
+++ b/MobileWallet/en.lproj/Localizable.strings
@@ -80,6 +80,7 @@
 "transaction.normal.title.pending.part.2" = "sent a payment";
 "transaction.normal.title.inbound.part.2" = "paid you";
 "transaction.normal.title.outbound.part.1" = "You paid";
+"transaction.unknown_source" = "Unknown Source";
 
 /* Authentication */
 "authentication.fail.title" = "Authentication failed";


### PR DESCRIPTION
- Added isUnknownUser computed value to TariAddress extension
- Added defaultAlias value to ContactModel
- defaultAlias is now used in the contact book and transaction list to replace formatted Tari address as a contact name with "Unknown Source" for addresses that are "unknown" (when raw emoji ID contains only zeros)