### PR TITLE
Frameworks update

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -338,7 +338,6 @@
 		491AB8A023F3FF4400372189 /* AddAmountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491AB89F23F3FF4400372189 /* AddAmountViewController.swift */; };
 		49996E1923F164BA002B6696 /* AnimatedBalanceLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49996E1823F164BA002B6696 /* AnimatedBalanceLabel.swift */; };
 		4C2C95C7237962CB005058AB /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C2C95C6237962CB005058AB /* libc++.tbd */; };
-		4C363B762574F15E00D99868 /* OpenSSL.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C363B372574EFE500D99868 /* OpenSSL.xcframework */; };
 		4CD20A362407967B007B64D8 /* TransportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD20A352407967B007B64D8 /* TransportConfig.swift */; };
 		4CDEC323273A5E3600999DCB /* Balance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDEC322273A5E3500999DCB /* Balance.swift */; };
 		515299BD56554003EF2BD2FD /* Pods_MobileWallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0A04F26CF08C60019DAC177 /* Pods_MobileWallet.framework */; };
@@ -919,7 +918,6 @@
 		49996E1823F164BA002B6696 /* AnimatedBalanceLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedBalanceLabel.swift; sourceTree = "<group>"; };
 		4C2C95B8237959B3005058AB /* MobileWallet-bridging-header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MobileWallet-bridging-header.h"; sourceTree = "<group>"; };
 		4C2C95C6237962CB005058AB /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
-		4C363B372574EFE500D99868 /* OpenSSL.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OpenSSL.xcframework; path = "Pods/OpenSSL-Universal/Frameworks/OpenSSL.xcframework"; sourceTree = "<group>"; };
 		4CD20A352407967B007B64D8 /* TransportConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConfig.swift; sourceTree = "<group>"; };
 		4CDEC322273A5E3500999DCB /* Balance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Balance.swift; sourceTree = "<group>"; };
 		540CB6ED29C1D519003FACEF /* SettingsProfileCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsProfileCell.swift; sourceTree = "<group>"; };
@@ -1145,7 +1143,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4C363B762574F15E00D99868 /* OpenSSL.xcframework in Frameworks */,
 				371189732488FF11004D0CE3 /* CloudKit.framework in Frameworks */,
 				00DC2E22238554FD00036DDC /* libsqlite3.tbd in Frameworks */,
 				0070A7BC2379847100C25E1C /* LocalAuthentication.framework in Frameworks */,
@@ -1501,7 +1498,6 @@
 			isa = PBXGroup;
 			children = (
 				542725652AFB7E1000FA4973 /* libminotari_wallet_ffi_ios.xcframework */,
-				4C363B372574EFE500D99868 /* OpenSSL.xcframework */,
 				371189722488FF11004D0CE3 /* CloudKit.framework */,
 				0070A7BB2379847100C25E1C /* LocalAuthentication.framework */,
 				00C520AE2469716E0077BF7F /* libc++.1.tbd */,

--- a/MobileWallet/Libraries/TariLib/Core/TorManager.swift
+++ b/MobileWallet/Libraries/TariLib/Core/TorManager.swift
@@ -249,7 +249,15 @@ final class TorManager {
     // MARK: - Proxy
 
     private func startIObfs4Proxy() {
-        IPtProxyStartObfs4Proxy(nil, false, false, nil)
+
+        guard let iptStateLocation = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent("pt_state").path else {
+            Logger.log(message: "No IPtProxy state location", domain: .tor, level: .error)
+            return
+        }
+
+        IPtProxy.setStateLocation(iptStateLocation)
+        IPtProxyStartLyrebird(nil, false, false, nil)
+        Logger.log(message: "IPtProxy state location set", domain: .tor, level: .info)
     }
 
     // MARK: - Controller

--- a/Podfile
+++ b/Podfile
@@ -1,18 +1,17 @@
-platform :ios, '13.0'
+platform :ios, '15.0'
 
 use_frameworks!
 inhibit_all_warnings!
 
 target 'MobileWallet' do
-  pod 'Tor', '408.7.2'
+  pod 'Tor', '408.10.1'
   pod 'lottie-ios'
   pod 'SwiftEntryKit', '2.0.0'
   pod 'ReachabilitySwift'
   pod 'Sentry', '8.14.2'
   pod 'SwiftKeychainWrapper', '3.4.0'
   pod 'Giphy', '2.1.22'
-  pod 'IPtProxy', '1.10.1'
-  pod 'OpenSSL-Universal'
+  pod 'IPtProxy', '3.3.0'
   pod 'Zip', '2.1.2'
   pod 'SwiftyDropbox', '8.2.1'
   pod 'YatLib', '0.3.3'
@@ -20,26 +19,9 @@ target 'MobileWallet' do
 end
 
 post_install do |installer|
-
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
-    end
-  end
-
-  installer.aggregate_targets.each do |target|
-      target.xcconfigs.each do |variant, xcconfig|
-      xcconfig_path = target.client_root + target.xcconfig_relative_path(variant)
-      IO.write(xcconfig_path, IO.read(xcconfig_path).gsub("DT_TOOLCHAIN_DIR", "TOOLCHAIN_DIR"))
-      end
-  end
-
-  installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      if config.base_configuration_reference.is_a? Xcodeproj::Project::Object::PBXFileReference
-          xcconfig_path = config.base_configuration_reference.real_path
-          IO.write(xcconfig_path, IO.read(xcconfig_path).gsub("DT_TOOLCHAIN_DIR", "TOOLCHAIN_DIR"))
-      end
     end
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Alamofire (5.4.4)
   - Giphy (2.1.22):
     - libwebp
-  - IPtProxy (1.10.1)
+  - IPtProxy (3.3.0)
   - libwebp (1.2.3):
     - libwebp/demux (= 1.2.3)
     - libwebp/mux (= 1.2.3)
@@ -13,7 +13,6 @@ PODS:
     - libwebp/demux
   - libwebp/webp (1.2.3)
   - lottie-ios (3.2.3)
-  - OpenSSL-Universal (1.1.1900)
   - ReachabilitySwift (5.0.0)
   - Sentry (8.14.2):
     - Sentry/Core (= 8.14.2)
@@ -26,10 +25,10 @@ PODS:
   - SwiftyDropbox (8.2.1):
     - Alamofire (~> 5.4.3)
   - TariCommon (0.2.0)
-  - Tor (408.7.2):
-    - Tor/CTor (= 408.7.2)
-  - Tor/Core (408.7.2)
-  - Tor/CTor (408.7.2):
+  - Tor (408.10.1):
+    - Tor/CTor (= 408.10.1)
+  - Tor/Core (408.10.1)
+  - Tor/CTor (408.10.1):
     - Tor/Core
   - YatLib (0.3.3):
     - TariCommon (~> 0.2.0)
@@ -37,16 +36,15 @@ PODS:
 
 DEPENDENCIES:
   - Giphy (= 2.1.22)
-  - IPtProxy (= 1.10.1)
+  - IPtProxy (= 3.3.0)
   - lottie-ios
-  - OpenSSL-Universal
   - ReachabilitySwift
   - Sentry (= 8.14.2)
   - SwiftEntryKit (= 2.0.0)
   - SwiftKeychainWrapper (= 3.4.0)
   - SwiftyDropbox (= 8.2.1)
   - TariCommon (= 0.2.0)
-  - Tor (= 408.7.2)
+  - Tor (= 408.10.1)
   - YatLib (= 0.3.3)
   - Zip (= 2.1.2)
 
@@ -57,7 +55,6 @@ SPEC REPOS:
     - IPtProxy
     - libwebp
     - lottie-ios
-    - OpenSSL-Universal
     - ReachabilitySwift
     - Sentry
     - SentryPrivate
@@ -72,10 +69,9 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
   Giphy: 6757d929878ef45f70ed62a02a2c9a03994e7b6c
-  IPtProxy: 17a32bf135d3824e8cbc3fba0fa5bc404490ac84
+  IPtProxy: 2136e276560ffd3a1d017683259f52552fc7c2e5
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
   lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
-  OpenSSL-Universal: 84efb8a29841f2764ac5403e0c4119a28b713346
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   Sentry: e0ea366f95ebb68f26d6030d8c22d6b2e6d23dd0
   SentryPrivate: 949a21fa59872427edc73b524c3ec8456761d97f
@@ -83,10 +79,10 @@ SPEC CHECKSUMS:
   SwiftKeychainWrapper: 6fc49fbf7d4a6b0772917acb0e53a1639f6078d6
   SwiftyDropbox: f6c55aae36c4ea944fe6b35f807c19897f78b09b
   TariCommon: 2c8bb97359f59d6b302d2e96c191ff95931da8ac
-  Tor: 7e7ab1fa8b5140b0b5038cff45b9c9472ad73951
+  Tor: 4aa4aee031f892efa43d1afb01c90565990c6312
   YatLib: f56aa60679b20e989a41b6bc92c0081c013b523a
   Zip: b3fef584b147b6e582b2256a9815c897d60ddc67
 
-PODFILE CHECKSUM: 78481b66b4ba45f09ba6fe28f4de98e3ab98cccf
+PODFILE CHECKSUM: ff47be47dc135ae36d0246cc2874a09b6898df7a
 
 COCOAPODS: 1.14.3

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Third-party frameworks and libraries are managed using a pre-compiled [Tari](htt
 - pod 'SwiftKeychainWrapper'
 - pod 'Giphy'
 - pod 'IPtProxy'
-- pod 'OpenSSL-Universal'
 - pod 'Zip'
 - pod 'SwiftyDropbox'
 - pod 'YatLib'
@@ -56,10 +55,6 @@ Third-party frameworks and libraries are managed using a pre-compiled [Tari](htt
     * The major revision will be increased only after significant and breaking changes.
     * The minor revision will be increased when new features or improvements are introduced.
     * The patch revision will be increased when the new version contains only hotfixes 
-
-### Folder Structure and Architecture
-
-Coming soon.
 
 ### Git Branches
 


### PR DESCRIPTION
- Updated Tor framework to 408.10.1
- Updated IPtProxy framework to 3.3.0
- Removed unused OpenSSL framework. This framework is used only internally by the Tor framework.
- Updated code to work with updated frameworks
- Updated README.md file
