### PR TITLE
0.25.1 Release

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -4005,7 +4005,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 0.25.0;
+				MARKETING_VERSION = 0.25.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tari.wallet;
 				PRODUCT_NAME = "Tari Aurora";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4038,7 +4038,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 0.25.0;
+				MARKETING_VERSION = 0.25.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tari.wallet;
 				PRODUCT_NAME = "Tari Aurora";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MobileWallet/Common/Deep Links/DeeplinkHandler.swift
+++ b/MobileWallet/Common/Deep Links/DeeplinkHandler.swift
@@ -42,8 +42,6 @@ import UIKit
 
 enum DeeplinkHandler {
 
-    private static var storedDeeplink: DeepLinkable?
-
     static func deeplink(rawDeeplink: String) throws -> DeepLinkable? {
 
         guard let deeplink = URL(string: rawDeeplink) else { return nil }
@@ -114,11 +112,8 @@ enum DeeplinkHandler {
     }
 
     private static func retryHandle(deeplink: DeepLinkable) {
-        storedDeeplink = deeplink
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            guard let storedDeeplink else { return }
-            self.storedDeeplink = nil
-            try? handle(deeplink: storedDeeplink, showDefaultDialogIfNeeded: true)
+            try? handle(deeplink: deeplink, showDefaultDialogIfNeeded: true)
         }
     }
 }

--- a/MobileWallet/Libraries/TariLib/Core/FFI/Wallet.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFI/Wallet.swift
@@ -170,8 +170,8 @@ final class Wallet {
 
     // MARK: - Deinitialiser
 
-    deinit {
-        Logger.log(message: "Wallet destoyed", domain: .general, level: .info)
+    func destroy() {
+        Logger.log(message: "Wallet destroyed", domain: .general, level: .info)
         wallet_destroy(pointer)
     }
 }

--- a/MobileWallet/SceneDelegate.swift
+++ b/MobileWallet/SceneDelegate.swift
@@ -58,7 +58,9 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // If the user opens a deep link while the app is closed
         if let url = connectionOptions.urlContexts.first?.url {
-            try? DeeplinkHandler.handle(rawDeeplink: url.absoluteString, showDefaultDialogIfNeeded: true)
+            DispatchQueue.main.async {
+                try? DeeplinkHandler.handle(rawDeeplink: url.absoluteString, showDefaultDialogIfNeeded: true)
+            }
         }
 
         // If the user opens a home screen shortcut while the app is closed

--- a/MobileWallet/UIElements/EmojiIdView.swift
+++ b/MobileWallet/UIElements/EmojiIdView.swift
@@ -96,7 +96,7 @@ final class EmojiIdView: DynamicThemeView {
         }
     }
 
-    private var superVC: UIViewController?
+    private weak var superVC: UIViewController?
 
     // MARK: - Updates
 

--- a/dependencies.env
+++ b/dependencies.env
@@ -1,1 +1,1 @@
-FFI_VERSION="1.0.0-rc.3"
+FFI_VERSION="1.0.0-rc.4"

--- a/dependencies.env
+++ b/dependencies.env
@@ -1,1 +1,1 @@
-FFI_VERSION="1.0.0-rc.4"
+FFI_VERSION="1.0.0-rc.5"


### PR DESCRIPTION
- Fixed issue with startup process when wallet_create returns 425 error on call.
- Wallet will no longer become a zombie object when the FFIWalletManager removes the reference to that object when the FFI is executing time-consuming async task.
- Removed retain cycle from EmojiIdView
- Updated FFI library to v.1.0.0-rc.5