### PR TITLE
Amounts on transaction cells are always negative

### DIFF
--- a/MobileWallet/Common/Formatters/TransactionFormatter.swift
+++ b/MobileWallet/Common/Formatters/TransactionFormatter.swift
@@ -129,7 +129,8 @@ final class TransactionFormatter {
 
     private func amountViewModel(transaction: Transaction) throws -> AmountBadge.ViewModel {
 
-        let amount = try MicroTari(transaction.amount).formattedWithNegativeOperator
+        let tariAmount = try MicroTari(transaction.amount)
+        let amount = try transaction.isOutboundTransaction ? tariAmount.formattedWithNegativeOperator : tariAmount.formattedWithOperator
 
         let valueType: AmountBadge.ValueType
 


### PR DESCRIPTION
- Fixed reported issue, now TransactionFormatter will format the amount as negative only when the transaction was ongoing.