### PR TITLE
The onboarding screen is unresponsive when the emoji ID view is expanded.

### DIFF
--- a/MobileWallet/UIElements/EmojiIdView.swift
+++ b/MobileWallet/UIElements/EmojiIdView.swift
@@ -280,6 +280,7 @@ final class EmojiIdView: DynamicThemeView {
     func expand(completion: (() -> Void)? = nil, callTapCompletion: Bool = false, animated: Bool = true) {
         guard let scrollViewFrame = condensedEmojiIdContainer.globalFrame else { return }
         secureContentView.isHidden = false
+        secureContentView.isUserInteractionEnabled = blackoutWhileExpanded
         tapActionIsDisabled = true
         expanded = true
         // If they're typing somewhere, close the keyboard


### PR DESCRIPTION
- Fixed issue with the onboarding screen. Now the screen still be responsive when the emoji ID view is expanded.
