### PR TITLE
iOS app displaying incorrect QR code on profile page

### DIFF
--- a/MobileWallet/Common/Protocols/AddressPoisoningDataHandler.swift
+++ b/MobileWallet/Common/Protocols/AddressPoisoningDataHandler.swift
@@ -51,7 +51,7 @@ enum AddressPoisoningDataHandler {
             return
         }
 
-        Task {
+        Task { @MainActor in
             do {
                 let address = try TariAddress(hex: rawAddress)
                 let similarAddresses = try await AddressPoisoningManager.shared.similarAddresses(address: address, includeInputAddress: true)

--- a/MobileWallet/Screens/Profile/ProfileModel.swift
+++ b/MobileWallet/Screens/Profile/ProfileModel.swift
@@ -187,14 +187,9 @@ final class ProfileModel {
     }
 
     private func makeDeeplink() throws -> URL? {
-
         guard let alias = name else { return nil }
         let hex = try Tari.shared.walletAddress.byteVector.hex
-
-        let deeplinkModel = ContactListDeeplink(list: [
-            ContactListDeeplink.Contact(alias: alias, hex: hex)
-        ])
-
+        let deeplinkModel = UserProfileDeeplink(alias: alias, tariAddress: hex)
         return try DeepLinkFormatter.deeplink(model: deeplinkModel)
     }
 


### PR DESCRIPTION
- Fixed reported issue. Now profile page generates te QR code with the "profile" deep link type.
- Fixed issue with the UI. Now AddressPoisoningDataHandler will always present UI on the main thread.
