### PR TITLE
Revert "available to spend" back to "available" balance.

### DIFF
--- a/MobileWallet/Libraries/TariLib/Core/Data Models/WalletBalance.swift
+++ b/MobileWallet/Libraries/TariLib/Core/Data Models/WalletBalance.swift
@@ -50,5 +50,4 @@ struct WalletBalance: Equatable {
 
 extension WalletBalance {
     var total: UInt64 { available + incoming }
-    var availableToSpend: UInt64 { available - timeLocked }
 }

--- a/MobileWallet/Libraries/TariLib/Core/Services/TariTransactionsService.swift
+++ b/MobileWallet/Libraries/TariLib/Core/Services/TariTransactionsService.swift
@@ -176,7 +176,7 @@ final class TariTransactionsService: CoreTariService {
 
         let estimatedFee = try walletManager.feeEstimate(amount: amount, feePerGram: feePerGram, kernelsCount: kernelsCount, outputsCount: outputsCount)
         let total = estimatedFee + amount
-        let availableBalance = services.walletBalance.balance.availableToSpend
+        let availableBalance = services.walletBalance.balance.available
 
         guard availableBalance >= total else {
             throw InternalError.insufficientFunds(spendableMicroTari: availableBalance)

--- a/MobileWallet/Screens/Home/Home/HomeModel.swift
+++ b/MobileWallet/Screens/Home/Home/HomeModel.swift
@@ -148,7 +148,7 @@ final class HomeModel {
 
     private func handle(walletBalance: WalletBalance) {
         balance = MicroTari(walletBalance.total).formatted
-        availableBalance = MicroTari(walletBalance.availableToSpend).formatted
+        availableBalance = MicroTari(walletBalance.available).formatted
     }
 
     private func handle(transactions: [Transaction]) {

--- a/MobileWallet/Screens/Send/AddAmount/AddAmountViewController.swift
+++ b/MobileWallet/Screens/Send/AddAmount/AddAmountViewController.swift
@@ -460,7 +460,7 @@ final class AddAmountViewController: DynamicThemeViewController {
 
     private func calculateAmount() -> MicroTari? {
 
-        let availableBalance = Tari.shared.walletBalance.balance.availableToSpend
+        let availableBalance = Tari.shared.walletBalance.balance.available
         var tariAmount: MicroTari?
 
         do {


### PR DESCRIPTION
- Replaced availableToSpend property to the available variable,
- Removed availableToSpend combined property from WalletBalance