### PR TITLE
Block Explorer per network

### DIFF
--- a/MobileWallet/Common/AppValues.swift
+++ b/MobileWallet/Common/AppValues.swift
@@ -40,7 +40,6 @@
 
 enum AppValues {
     static let general = GeneralValues.self
-    static let blockExplorer = BlockExplorerValues.self
 }
 
 enum GeneralValues {
@@ -51,9 +50,4 @@ enum GeneralValues {
         return false
         #endif
     }
-}
-
-enum BlockExplorerValues {
-    static var baseURL: URL? { URL(string: "https://explore-nextnet.tari.com") }
-    static func kernelURL(nounce: String, signature: String) -> URL? { URL(string: "https://explore-nextnet.tari.com/kernel_search?nonces=\(nounce)&signatures=\(signature)") }
 }

--- a/MobileWallet/Libraries/TariLib/Wrappers/Utils/Network/TariNetwork.swift
+++ b/MobileWallet/Libraries/TariLib/Wrappers/Utils/Network/TariNetwork.swift
@@ -44,6 +44,7 @@ struct TariNetwork {
     let tickerSymbol: String
     let isRecommended: Bool
     let dnsPeer: String
+    let blockExplorerURL: URL?
 }
 
 extension TariNetwork {
@@ -56,7 +57,19 @@ extension TariNetwork {
             presentedName: "StageNet",
             isMainNet: false,
             isRecommended: true,
-            dnsPeer: "seeds.stagenet.tari.com"
+            dnsPeer: "seeds.stagenet.tari.com",
+            blockExplorerURL: nil
+        )
+    }
+
+    static var nextnet: Self {
+        makeNetwork(
+            name: "nextnet",
+            presentedName: "NextNet",
+            isMainNet: false,
+            isRecommended: false,
+            dnsPeer: "seeds.nextnet.tari.com",
+            blockExplorerURL: URL(string: "https://explore-nextnet.tari.com")
         )
     }
 
@@ -65,8 +78,24 @@ extension TariNetwork {
         return "\(presentedName) (\(localized("common.recommended")))"
     }
 
-    private static func makeNetwork(name: String, presentedName: String, isMainNet: Bool, isRecommended: Bool, dnsPeer: String) -> Self {
+    var isBlockExplorerAvailable: Bool { blockExplorerURL != nil }
+
+    func blockExplorerKernelURL(nounce: String, signature: String) -> URL? {
+        if #available(iOS 16.0, *) {
+            return blockExplorerURL?
+                .appending(path: "kernel_search")
+                .appending(queryItems: [
+                    URLQueryItem(name: "nonces", value: nounce),
+                    URLQueryItem(name: "signatures", value: signature)
+                ])
+        } else {
+            guard let rawURL = blockExplorerURL?.absoluteString.appending("/kernel_search?nonces=\(nounce)&signatures=\(signature)") else { return nil }
+            return URL(string: rawURL)
+        }
+    }
+
+    private static func makeNetwork(name: String, presentedName: String, isMainNet: Bool, isRecommended: Bool, dnsPeer: String, blockExplorerURL: URL?) -> Self {
         let currencySymbol = isMainNet ? "XTR" : "tXTR"
-        return Self(name: name, presentedName: presentedName, tickerSymbol: currencySymbol, isRecommended: isRecommended, dnsPeer: dnsPeer)
+        return Self(name: name, presentedName: presentedName, tickerSymbol: currencySymbol, isRecommended: isRecommended, dnsPeer: dnsPeer, blockExplorerURL: blockExplorerURL)
     }
 }

--- a/MobileWallet/Screens/Home/Transaction Details/TransactionDetailsModel.swift
+++ b/MobileWallet/Screens/Home/Transaction Details/TransactionDetailsModel.swift
@@ -283,8 +283,8 @@ final class TransactionDetailsModel {
     }
 
     private func fetchLinkToOpen() -> URL? {
-        guard let transactionNounce = transactionNounce, let transactionSignature = transactionSignature else { return nil }
-        return AppValues.blockExplorer.kernelURL(nounce: transactionNounce, signature: transactionSignature)
+        guard let transactionNounce, let transactionSignature else { return nil }
+        return NetworkManager.shared.selectedNetwork.blockExplorerKernelURL(nounce: transactionNounce, signature: transactionSignature)
     }
 
     private func handle(transaction: Transaction) {
@@ -330,7 +330,7 @@ final class TransactionDetailsModel {
     private func handleTransactionKernel() {
 
         defer {
-            isBlockExplorerActionAvailable = transactionNounce != nil && transactionSignature != nil
+            isBlockExplorerActionAvailable = NetworkManager.shared.selectedNetwork.isBlockExplorerAvailable && transactionNounce != nil && transactionSignature != nil
         }
 
         guard let kernel = try? (transaction as? CompletedTransaction)?.transactionKernel else {

--- a/MobileWallet/Screens/Settings/SettingsViewController.swift
+++ b/MobileWallet/Screens/Settings/SettingsViewController.swift
@@ -135,7 +135,8 @@ final class SettingsViewController: SettingsParentTableViewController {
     ]
 
     private let moreSectionItems: [SystemMenuTableViewCellItem] = {
-        [
+
+        var items = [
             SystemMenuTableViewCellItem(icon: Theme.shared.images.settingsAboutIcon, title: SettingsItemTitle.about.rawValue),
             SystemMenuTableViewCellItem(icon: Theme.shared.images.settingsReportBugIcon, title: SettingsItemTitle.reportBug.rawValue),
             SystemMenuTableViewCellItem(icon: Theme.shared.images.settingsVisitTariIcon, title: SettingsItemTitle.visitTari.rawValue),
@@ -143,8 +144,13 @@ final class SettingsViewController: SettingsParentTableViewController {
             SystemMenuTableViewCellItem(icon: Theme.shared.images.settingsUserAgreementIcon, title: SettingsItemTitle.userAgreement.rawValue),
             SystemMenuTableViewCellItem(icon: Theme.shared.images.settingsPrivacyPolicyIcon, title: SettingsItemTitle.privacyPolicy.rawValue),
             SystemMenuTableViewCellItem(icon: Theme.shared.images.settingsDisclaimerIcon, title: SettingsItemTitle.disclaimer.rawValue),
-            SystemMenuTableViewCellItem(icon: Theme.shared.images.settingsBlockExplorerIcon, title: SettingsItemTitle.blockExplorer.rawValue)
         ]
+
+        if NetworkManager.shared.selectedNetwork.isBlockExplorerAvailable {
+            items.append(SystemMenuTableViewCellItem(icon: Theme.shared.images.settingsBlockExplorerIcon, title: SettingsItemTitle.blockExplorer.rawValue))
+        }
+
+        return items
     }()
 
     private let links: [SettingsItemTitle: URL?] = [
@@ -153,7 +159,7 @@ final class SettingsViewController: SettingsParentTableViewController {
         .userAgreement: URL(string: TariSettings.shared.userAgreementUrl),
         .privacyPolicy: URL(string: TariSettings.shared.privacyPolicyUrl),
         .disclaimer: URL(string: TariSettings.shared.disclaimer),
-        .blockExplorer: AppValues.blockExplorer.baseURL
+        .blockExplorer: NetworkManager.shared.selectedNetwork.blockExplorerURL
     ]
 
     private let profileIndexPath = IndexPath(row: 0, section: 0)


### PR DESCRIPTION
- Added a new field to TariNetwork. blockExplorerURL will store block explorer URL related to the network. When blockExplorerURL is nil then the block explorer feature is disabled in the app.
- Added NextNet TariNetwork configuration