### PR TITLE
Send button doesn't start transaction flow

### DIFF
--- a/MobileWallet/Screens/Contact Book/List/ContactBookViewController.swift
+++ b/MobileWallet/Screens/Contact Book/List/ContactBookViewController.swift
@@ -364,9 +364,10 @@ final class ContactBookViewController: SecureViewController<ContactBookView>, Ov
 
         let overlay = RotaryMenuOverlay(model: model)
 
-        overlay.onMenuButtonTap = { [weak self] in
-            self?.dismiss(animated: true)
-            self?.model.performAction(contactID: $0, menuItemID: $1)
+        overlay.onMenuButtonTap = { [weak self] contactID, menuItemID in
+            self?.dismiss(animated: true) {
+                self?.model.performAction(contactID: contactID, menuItemID: menuItemID)
+            }
         }
 
         show(overlay: overlay)


### PR DESCRIPTION
- Fixed reported issue. Now, the send button on the contact book screen will again start the transaction flow with the selected contact.
