### PR TITLE
Wallet logging

### DIFF
--- a/MobileWallet/Libraries/TariLib/Core/FFI/Wallet.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFI/Wallet.swift
@@ -170,7 +170,7 @@ final class Wallet {
     // MARK: - Deinitialiser
 
     func destroy() {
-        Logger.log(message: "Wallet destroyed", domain: .general, level: .info)
         wallet_destroy(pointer)
+        Logger.log(message: "Wallet destroyed", domain: .general, level: .info)
     }
 }


### PR DESCRIPTION
- Switched methods executed in Wallet.destroy() method. Now, the app will log the "Wallet destroyed" message after it calls the wallet_destroy().