### PR TITLE
New Tari Address Format - Misc/Minor issues

### DIFF
--- a/MobileWallet/Backup/Manager/BackupFilesManager.swift
+++ b/MobileWallet/Backup/Manager/BackupFilesManager.swift
@@ -81,7 +81,7 @@ enum BackupFilesManager {
             .all
             .map { try $0.json }
 
-        let model = PartialBackupModel(source: try Tari.shared.walletAddress.byteVector.hex, utxos: rawUTXOs)
+        let model = PartialBackupModel(source: try Tari.shared.walletAddress.components.fullRaw, utxos: rawUTXOs)
         let data = try jsonEncoder.encode(model)
 
         let fileURL = workingDirectory.appendingPathComponent(unencryptedFileName)

--- a/MobileWallet/Common/Managers/BLE/BLEPeripheralManager.swift
+++ b/MobileWallet/Common/Managers/BLE/BLEPeripheralManager.swift
@@ -255,7 +255,7 @@ final class BLEPeripheralManager: NSObject {
     // MARK: - Helpers
 
     private func makeUserProfileDeeplinkChunks() -> [Data] {
-        guard let alias = UserSettingsManager.name, let address = try? Tari.shared.walletAddress.byteVector.hex else { return [] }
+        guard let alias = UserSettingsManager.name, let address = try? Tari.shared.walletAddress.components.fullRaw else { return [] }
         let model = UserProfileDeeplink(alias: alias, tariAddress: address)
         guard let url = try? DeepLinkFormatter.deeplink(model: model) else { return [] }
         return url.absoluteString.data(using: .utf8)?.bleDataChunks ?? []


### PR DESCRIPTION
- Fixed reported issues with BLE contact shearing. Now, the user will be able to share his new Tari address using BLE.
- Now, partial backups will use the new Tari address format.