### PR TITLE
Push Notification - New Tari address format

### DIFF
--- a/MobileWallet/AppDelegate.swift
+++ b/MobileWallet/AppDelegate.swift
@@ -99,7 +99,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
         let hexString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
-        Logger.log(message: "Registed for push notifications with token \(hexString).", domain: .general, level: .info)
+        Logger.log(message: "Registered for push notifications with token \(hexString).", domain: .general, level: .info)
         NotificationManager.shared.registerDeviceToken(deviceToken)
     }
 

--- a/MobileWallet/Common/Managers/WalletTransactionsManager.swift
+++ b/MobileWallet/Common/Managers/WalletTransactionsManager.swift
@@ -126,7 +126,7 @@ final class WalletTransactionsManager {
                 result(.success)
                 return
             }
-            try startListeningForWalletEvents(transactionID: transactionID, publicKey: tariAddress.publicKey, result: result)
+            try startListeningForWalletEvents(transactionID: transactionID, publicKey: tariAddress.spendKey.byteVector.hex, result: result)
         } catch {
             result(.failure(.transactionError(error: error)))
         }

--- a/MobileWallet/Common/NotificationManager.swift
+++ b/MobileWallet/Common/NotificationManager.swift
@@ -227,7 +227,7 @@ final class NotificationManager {
     }
 
     private func sign(message: String) throws -> (hex: String, metadata: MessageMetadata) {
-        let hex = try Tari.shared.walletAddress.publicKey
+        let hex = try Tari.shared.walletAddress.spendKey.byteVector.hex
         guard let apiKey = TariSettings.shared.pushServerApiKey else { throw PushNotificationServerError.missingApiKey }
         let metadata = try Tari.shared.messageSign.sign(message: "\(apiKey)\(hex)\(message)")
         return (hex: hex, metadata: metadata)


### PR DESCRIPTION
- Push notification manager is now using the spend key to send remote push notifications.