### PR TITLE
Failed wallet recovery unexpectedly still creates wallet from seeds

### DIFF
--- a/MobileWallet/Libraries/TariLib/Core/Services/CoreTariService.swift
+++ b/MobileWallet/Libraries/TariLib/Core/Services/CoreTariService.swift
@@ -39,6 +39,7 @@
 */
 
 protocol MainServiceable: AnyObject {
+    var connection: TariConnectionService { get }
     var validation: TariValidationService { get }
     var walletBalance: TariBalanceService { get }
 }

--- a/MobileWallet/Libraries/TariLib/Core/Services/TariRecoveryService.swift
+++ b/MobileWallet/Libraries/TariLib/Core/Services/TariRecoveryService.swift
@@ -49,7 +49,14 @@ final class TariRecoveryService: CoreTariService {
     // MARK: - Actions
 
     func startRecovery(recoveredOutputMessage: String) throws -> Bool {
-        guard let selectedBaseNode = NetworkManager.shared.selectedBaseNode else { return false }
+
+        var selectedBaseNode = NetworkManager.shared.selectedBaseNode
+
+        if selectedBaseNode == nil {
+            selectedBaseNode = try services.connection.defaultBaseNodePeers().randomElement()
+        }
+
+        guard let selectedBaseNode else { return false }
         return try walletManager.startRecovery(baseNodePublicKey: selectedBaseNode.makePublicKey(), recoveredOutputMessage: recoveredOutputMessage)
     }
 

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/RestoreWalletFromSeedsModel.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/RestoreWalletFromSeedsModel.swift
@@ -166,7 +166,15 @@ final class RestoreWalletFromSeedsModel {
         }
     }
 
+    func deleteWallet() {
+        Tari.shared.deleteWallet()
+        Tari.shared.canAutomaticalyReconnectWallet = false
+    }
+
     private func restoreWallet(seedWords: [String]) {
+
+        deleteWallet()
+
         do {
             try Tari.shared.restoreWallet(seedWords: seedWords)
             try selectCustomBaseNode()

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/RestoreWalletFromSeedsViewController.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/RestoreWalletFromSeedsViewController.swift
@@ -143,6 +143,10 @@ final class RestoreWalletFromSeedsViewController: SecureViewController<RestoreWa
             AppRouter.transitionToSplashScreen(isWalletConnected: true)
         }
 
+        overlay.onFailure = { [weak self] in
+            self?.model.deleteWallet()
+        }
+
         show(overlay: overlay)
     }
 

--- a/MobileWallet/Screens/RestoreWalletFromSeedsProgress/SeedWordsRecoveryProgressViewController.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeedsProgress/SeedWordsRecoveryProgressViewController.swift
@@ -46,6 +46,7 @@ final class SeedWordsRecoveryProgressViewController: SecureViewController<SeedWo
     // MARK: - Properties
 
     var onSuccess: (() -> Void)?
+    var onFailure: (() -> Void)?
 
     private let model = SeedWordsRecoveryProgressModel()
     private var cancelables: Set<AnyCancellable> = []
@@ -86,6 +87,7 @@ final class SeedWordsRecoveryProgressViewController: SecureViewController<SeedWo
         PopUpPresenter.showMessageWithCloseButton(message: errorModel) { [weak self] in
             self?.dismiss(animated: true)
         }
+        onFailure?()
     }
 
     private func handle(isWalletRestored: Bool) {


### PR DESCRIPTION
- Fixed reported issue. Now, the App will clean up wallet folder after the recovery failure and before the recovery.
- Fixed issue with selecting base node for recovery. Now, when user doesn't specify the base node the recovery will be performed on a random one from the fetched peer list.