### PR TITLE
Recovery/Onboarding screenshot prevention pop-up handling

### DIFF
--- a/MobileWallet/Common/Pop-up/Handlers/ScreenshotPopUpHandler.swift
+++ b/MobileWallet/Common/Pop-up/Handlers/ScreenshotPopUpHandler.swift
@@ -68,13 +68,18 @@ final class ScreenshotPopUpHandler {
 
     private func showPopUp() {
 
+        var buttons = [
+            PopUpDialogButtonModel(title: localized("screen_recording.pop_up.button.ok"), type: .normal)
+        ]
+
+        if AppRouter.isNavigationReady {
+            buttons.append(PopUpDialogButtonModel(title: localized("screen_recording.pop_up.button.enable"), type: .text, callback: { [weak self] in self?.showScreenShotSettingsScreen() }))
+        }
+
         let model = PopUpDialogModel(
             title: localized("screen_recording.pop_up.title"),
-            message: localized("screen_recording.pop_up.message"),
-            buttons: [
-                PopUpDialogButtonModel(title: localized("screen_recording.pop_up.button.ok"), type: .normal),
-                PopUpDialogButtonModel(title: localized("screen_recording.pop_up.button.enable"), type: .text, callback: { [weak self] in self?.showScreenShotSettingsScreen() })
-            ],
+            message: AppRouter.isNavigationReady ? localized("screen_recording.pop_up.message.normal") : localized("screen_recording.pop_up.message.simple"),
+            buttons: buttons,
             hapticType: .error
         )
 

--- a/MobileWallet/en.lproj/Localizable.strings
+++ b/MobileWallet/en.lproj/Localizable.strings
@@ -916,7 +916,8 @@
 /* Screen Recording Pop-Up */
 
 "screen_recording.pop_up.title" = "Screenshots Disabled";
-"screen_recording.pop_up.message" = "Oops! Screenshots are disabled in this app to keep your information safe. Thanks for keeping things secure!";
+"screen_recording.pop_up.message.normal" = "Oops! Screenshots are disabled in this app to keep your information safe. Thanks for keeping things secure!";
+"screen_recording.pop_up.message.simple" = "Oops! Screenshots are disabled in this app to keep your information safe. You can always change this later in settings. Thanks for keeping things secure!";
 "screen_recording.pop_up.button.ok" = "No problem, mate!";
 "screen_recording.pop_up.button.enable" = "Enable screenshots";
 


### PR DESCRIPTION
- Disabled navigation to the settings screen when it's unavailable (e.g. when user still doesn't reach the home screen).