### PR TITLE
User keeps on seeing "Creating your wallet" flow when they open the App

### DIFF
--- a/MobileWallet/Libraries/TariLib/Wrappers/Utils/Settings/Wallet/WalletSettingsManager.swift
+++ b/MobileWallet/Libraries/TariLib/Wrappers/Utils/Settings/Wallet/WalletSettingsManager.swift
@@ -42,9 +42,7 @@ final class WalletSettingsManager {
 
     private var settings: WalletSettings {
 
-        guard let networkName = GroupUserDefaults.selectedNetworkName else {
-            return makeWalletSettings(networkName: "")
-        }
+        let networkName = NetworkManager.shared.selectedNetwork.name
 
         guard let existingSettings = GroupUserDefaults.walletSettings?.first(where: { $0.networkName == networkName }) else {
             var settings = GroupUserDefaults.walletSettings ?? []


### PR DESCRIPTION
- Fixed reported issue. Now, the app will no longer show onboarding on every start when user recover his wallet from seed words.