### PR TITLE
Can't click on antenna icon

### DIFF
--- a/MobileWallet/Common/Pop-up/PopUpPresenter.swift
+++ b/MobileWallet/Common/Pop-up/PopUpPresenter.swift
@@ -88,7 +88,10 @@ enum PopUpPresenter {
             attributes.hapticFeedbackType = makeHapticFeedbackType(configuration: configuration)
         }
 
-        SwiftEntryKit.display(entry: popUp, using: attributes)
+        DispatchQueue.main.async {
+            SwiftEntryKit.display(entry: popUp, using: attributes)
+        }
+
         UIApplication.shared.hideKeyboard()
     }
 


### PR DESCRIPTION
- Fixed reported issue. Now the PopUpPresenter will be enforce SwiftEntryKit.display() to run on the main thread.