### PR TITLE
Antenna icon is not clickable

### DIFF
--- a/MobileWallet/Libraries/TariLib/Wrappers/Utils/Loggers/CrashLogger.swift
+++ b/MobileWallet/Libraries/TariLib/Wrappers/Utils/Loggers/CrashLogger.swift
@@ -74,7 +74,7 @@ final class CrashLogger {
 
         GroupUserDefaults.isTrackingEnabled = isEnabled
 
-        if isEnabled == true {
+        if isEnabled == nil || isEnabled == true {
             start()
         } else {
             stop()

--- a/MobileWallet/Screens/AppEntry/Splash/SplashViewController.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/SplashViewController.swift
@@ -75,11 +75,6 @@ final class SplashViewController: UIViewController {
         setupCallbacks()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        TrackingConsentManager.handleTrackingConsent()
-    }
-
     // MARK: - Setups
 
     private func setupCallbacks() {

--- a/MobileWallet/Screens/Home/Home/HomeViewController.swift
+++ b/MobileWallet/Screens/Home/Home/HomeViewController.swift
@@ -76,6 +76,7 @@ final class HomeViewController: SecureViewController<HomeView> {
         super.viewDidAppear(animated)
         mainView.startAnimations()
         model.executeQueuedShortcut()
+        showTrackingConsentPopUp()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -185,5 +186,11 @@ final class HomeViewController: SecureViewController<HomeView> {
         )
 
         PopUpPresenter.showPopUp(model: popUpModel)
+    }
+
+    private func showTrackingConsentPopUp() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            TrackingConsentManager.handleTrackingConsent()
+        }
     }
 }


### PR DESCRIPTION
- Fixed reported issue. Moved tracing consent dialog from splash to home screen and added a delay to be sure that pop-up window layer constraints was calculated properly even on slower devices.