### PR TITLE
Paper wallet: Create a wallet from paper wallet

### DIFF
--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 		54103CE02A555A4500C456B4 /* TransactionHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54103CDF2A555A4500C456B4 /* TransactionHistoryView.swift */; };
 		54103CE22A5564CA00C456B4 /* TransactionHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54103CE12A5564CA00C456B4 /* TransactionHistoryCell.swift */; };
 		5410F5D12951F04B006976DC /* TariWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5410F5D02951F04B006976DC /* TariWindow.swift */; };
+		54150C312CAD3132005B2C9D /* RestoreWalletModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54150C302CAD3132005B2C9D /* RestoreWalletModel.swift */; };
 		5419AA792A4473F90079E745 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5419AA782A4473F90079E745 /* HomeViewController.swift */; };
 		5419AA7B2A4474040079E745 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5419AA7A2A4474040079E745 /* HomeView.swift */; };
 		5419AA7D2A4474390079E745 /* HomeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5419AA7C2A4474390079E745 /* HomeModel.swift */; };
@@ -394,6 +395,7 @@
 		544692A429B6059C0081085D /* ContactsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544692A329B6059C0081085D /* ContactsManager.swift */; };
 		544D9D4C296D9B2000D8ECEF /* UnblindedOutputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544D9D4B296D9B2000D8ECEF /* UnblindedOutputs.swift */; };
 		544D9D4E296D9B3300D8ECEF /* UnblindedOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544D9D4D296D9B3300D8ECEF /* UnblindedOutput.swift */; };
+		54516C0C2CAE851D00A8A2FB /* SeedWordsWalletRecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54516C0B2CAE851D00A8A2FB /* SeedWordsWalletRecoveryManager.swift */; };
 		5453241A29A60C6E009281A7 /* TariPagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5453241929A60C6E009281A7 /* TariPagerViewController.swift */; };
 		5453241C29A60CA0009281A7 /* TariPagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5453241B29A60CA0009281A7 /* TariPagerView.swift */; };
 		5453242029A68310009281A7 /* PageToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5453241F29A68310009281A7 /* PageToolbarView.swift */; };
@@ -528,6 +530,7 @@
 		54F2E34C29EE9FFC00A7A15A /* ContactTransactionListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F2E34B29EE9FFC00A7A15A /* ContactTransactionListHeaderView.swift */; };
 		54F2E34E29EEAEBB00A7A15A /* ContactTransactionListPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F2E34D29EEAEBB00A7A15A /* ContactTransactionListPlaceholder.swift */; };
 		54F306112A3B049500B5689D /* UIView+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F306102A3B049500B5689D /* UIView+Utils.swift */; };
+		54F323E92CAC501300FD5364 /* PaperWalletDeeplink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F323E82CAC501300FD5364 /* PaperWalletDeeplink.swift */; };
 		54F9C5A42AA712F100DA87D8 /* CustomTorBridgesInputCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F9C5A32AA712F100DA87D8 /* CustomTorBridgesInputCell.swift */; };
 		54FCC3672AA5C2D100CA0025 /* TorBridgesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FCC3662AA5C2D100CA0025 /* TorBridgesViewController.swift */; };
 		54FCC3692AA5C2DB00CA0025 /* TorBridgesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FCC3682AA5C2DB00CA0025 /* TorBridgesView.swift */; };
@@ -941,6 +944,7 @@
 		54103CDF2A555A4500C456B4 /* TransactionHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryView.swift; sourceTree = "<group>"; };
 		54103CE12A5564CA00C456B4 /* TransactionHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryCell.swift; sourceTree = "<group>"; };
 		5410F5D02951F04B006976DC /* TariWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TariWindow.swift; sourceTree = "<group>"; };
+		54150C302CAD3132005B2C9D /* RestoreWalletModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreWalletModel.swift; sourceTree = "<group>"; };
 		5419AA782A4473F90079E745 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		5419AA7A2A4474040079E745 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		5419AA7C2A4474390079E745 /* HomeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModel.swift; sourceTree = "<group>"; };
@@ -980,6 +984,7 @@
 		544692A329B6059C0081085D /* ContactsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsManager.swift; sourceTree = "<group>"; };
 		544D9D4B296D9B2000D8ECEF /* UnblindedOutputs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnblindedOutputs.swift; sourceTree = "<group>"; };
 		544D9D4D296D9B3300D8ECEF /* UnblindedOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnblindedOutput.swift; sourceTree = "<group>"; };
+		54516C0B2CAE851D00A8A2FB /* SeedWordsWalletRecoveryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedWordsWalletRecoveryManager.swift; sourceTree = "<group>"; };
 		5453241929A60C6E009281A7 /* TariPagerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TariPagerViewController.swift; sourceTree = "<group>"; };
 		5453241B29A60CA0009281A7 /* TariPagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TariPagerView.swift; sourceTree = "<group>"; };
 		5453241F29A68310009281A7 /* PageToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageToolbarView.swift; sourceTree = "<group>"; };
@@ -1114,6 +1119,7 @@
 		54F2E34B29EE9FFC00A7A15A /* ContactTransactionListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTransactionListHeaderView.swift; sourceTree = "<group>"; };
 		54F2E34D29EEAEBB00A7A15A /* ContactTransactionListPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTransactionListPlaceholder.swift; sourceTree = "<group>"; };
 		54F306102A3B049500B5689D /* UIView+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Utils.swift"; sourceTree = "<group>"; };
+		54F323E82CAC501300FD5364 /* PaperWalletDeeplink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperWalletDeeplink.swift; sourceTree = "<group>"; };
 		54F9C5A32AA712F100DA87D8 /* CustomTorBridgesInputCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTorBridgesInputCell.swift; sourceTree = "<group>"; };
 		54FCC3662AA5C2D100CA0025 /* TorBridgesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorBridgesViewController.swift; sourceTree = "<group>"; };
 		54FCC3682AA5C2DB00CA0025 /* TorBridgesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorBridgesView.swift; sourceTree = "<group>"; };
@@ -1524,6 +1530,7 @@
 			isa = PBXGroup;
 			children = (
 				3704926F247EA0770034EE5D /* RestoreWalletViewController.swift */,
+				54150C302CAD3132005B2C9D /* RestoreWalletModel.swift */,
 			);
 			path = RestoreWallet;
 			sourceTree = "<group>";
@@ -1836,6 +1843,7 @@
 			isa = PBXGroup;
 			children = (
 				54885B1729E7FE91009175AC /* BLE */,
+				54D1CCBF2B4D4C7200808535 /* AddressPoisoningManager.swift */,
 				5482C8CF2A71105700C2C80A /* AnimationHandler.swift */,
 				3A8CC6C1290BDC70008161DC /* BugReportService.swift */,
 				54A9C88729F6A06F009B0653 /* DataFlowManager.swift */,
@@ -1845,12 +1853,12 @@
 				3A3E8BF22924FB4C00490E57 /* MigrationManager.swift */,
 				54C416242A1CA81700454096 /* PendingDataManager.swift */,
 				54E007B52B8DF55600AFCD7C /* SecurityManager.swift */,
+				54516C0B2CAE851D00A8A2FB /* SeedWordsWalletRecoveryManager.swift */,
 				3AF97E6F27CFCA2000FF6A3F /* ShortcutsManager.swift */,
 				54A6E9EF297F1F9900A60853 /* StagedWalletSecurityManager.swift */,
 				54C7EB5F2AC6B22C00F387DF /* TrackingConsentManager.swift */,
 				549E1A022A5EC2260063022C /* VideoCaptureManager.swift */,
 				3A052BF927B2940900C93671 /* WalletTransactionsManager.swift */,
-				54D1CCBF2B4D4C7200808535 /* AddressPoisoningManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -2503,6 +2511,7 @@
 				3AF97E6627CF769A00FF6A3F /* BaseNodesAddDeeplink.swift */,
 				544013A329E0003100B5DD6D /* ContactListDeeplink.swift */,
 				54BB5E042A2F081300E239C7 /* UserProfileDeeplink.swift */,
+				54F323E82CAC501300FD5364 /* PaperWalletDeeplink.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3388,6 +3397,7 @@
 				001F6CE42380253B00FA7002 /* Contact.swift in Sources */,
 				3AF97E6927CF76C800FF6A3F /* DeeplinkHandler.swift in Sources */,
 				00DD160F241CD41D00C955B4 /* BaseNode.swift in Sources */,
+				54F323E92CAC501300FD5364 /* PaperWalletDeeplink.swift in Sources */,
 				3AF97E6527CF767D00FF6A3F /* TransactionsSendDeeplink.swift in Sources */,
 				54BB5E052A2F081300E239C7 /* UserProfileDeeplink.swift in Sources */,
 				3A0391E8290BA45C00352D73 /* BugReportingModel.swift in Sources */,
@@ -3472,6 +3482,7 @@
 				54D782F62BA8616F00DD3BFE /* BaseNodeState.swift in Sources */,
 				37765D2624A35BA20091AE2A /* AESEncryption.swift in Sources */,
 				3A82455627E1EE0D003B6B59 /* TransactionDetailsSectionView.swift in Sources */,
+				54516C0C2CAE851D00A8A2FB /* SeedWordsWalletRecoveryManager.swift in Sources */,
 				54AD5F662A420A9F00D223B8 /* Data+Utlis.swift in Sources */,
 				54621F9029E01385000E9659 /* DeeplinkUnkeyedDecodingContainer.swift in Sources */,
 				3A7DAB9528FDB220002CC013 /* LogsListCell.swift in Sources */,
@@ -3853,6 +3864,7 @@
 				3A793BF3280354830094DF23 /* PopUpHeaderWithSubtitle.swift in Sources */,
 				3A3E7AD6284E03140065F3C0 /* UTXOTileView.swift in Sources */,
 				3A420594279802E500A8D49C /* BaseButton.swift in Sources */,
+				54150C312CAD3132005B2C9D /* RestoreWalletModel.swift in Sources */,
 				3ABBBA7E2850815C00A3108D /* UTXOsWalletTileListView.swift in Sources */,
 				546B03232983B49400DBED8E /* StylizedLabel.swift in Sources */,
 				54D1CCC02B4D4C7200808535 /* AddressPoisoningManager.swift in Sources */,

--- a/MobileWallet/Common/AppRouter.swift
+++ b/MobileWallet/Common/AppRouter.swift
@@ -189,9 +189,9 @@ enum AppRouter {
         }
     }
 
-    @MainActor static func presentQrCodeScanner(expectedDataTypes: [QRCodeScannerModel.ExpectedType], onExpectedDataScan: ((QRCodeData) -> Void)?) {
+    @MainActor static func presentQrCodeScanner(expectedDataTypes: [QRCodeScannerModel.DataType], disabledDataTypes: [QRCodeScannerModel.DataType], onExpectedDataScan: ((QRCodeData) -> Void)?) {
         do {
-            let controller = try QRCodeScannerConstructor.buildScene(expectedDataTypes: expectedDataTypes)
+            let controller = try QRCodeScannerConstructor.buildScene(expectedDataTypes: expectedDataTypes, disabledDataTypes: disabledDataTypes)
             controller.onExpectedDataScan = onExpectedDataScan
             presentOnTop(controller: controller)
         } catch {

--- a/MobileWallet/Common/Deep Links/Data Handling/DeepLinkFormatter.swift
+++ b/MobileWallet/Common/Deep Links/Data Handling/DeepLinkFormatter.swift
@@ -43,6 +43,7 @@ enum DeeplinkType: String {
     case baseNodesAdd = "/base_nodes/add"
     case contacts = "/contacts"
     case profile = "/profile"
+    case paperWallet = "/paper_wallet"
 }
 
 protocol DeepLinkable: Codable {

--- a/MobileWallet/Common/Deep Links/DeeplinkHandler.swift
+++ b/MobileWallet/Common/Deep Links/DeeplinkHandler.swift
@@ -56,6 +56,8 @@ enum DeeplinkHandler {
             return try DeepLinkFormatter.model(type: ContactListDeeplink.self, deeplink: deeplink)
         case .profile:
             return try DeepLinkFormatter.model(type: UserProfileDeeplink.self, deeplink: deeplink)
+        case .paperWallet:
+            return try DeepLinkFormatter.model(type: PaperWalletDeeplink.self, deeplink: deeplink)
         }
     }
 
@@ -88,6 +90,8 @@ enum DeeplinkHandler {
             try handle(userProfileDeepLink: deeplink, actionType: actionType)
         case .transactionSend:
             handle(transactionSendDeepLink: deeplink)
+        case .paperWallet:
+            break
         }
     }
 

--- a/MobileWallet/Common/Deep Links/Models/PaperWalletDeeplink.swift
+++ b/MobileWallet/Common/Deep Links/Models/PaperWalletDeeplink.swift
@@ -1,10 +1,10 @@
-//  QRCodeScannerConstructor.swift
+//  PaperWalletDeeplink.swift
 
 /*
 	Package MobileWallet
-	Created by Adrian Truszczyński on 11/07/2023
+	Created by Adrian Truszczyński on 01/10/2024
 	Using Swift 5.0
-	Running on macOS 13.4
+	Running on macOS 14.6
 
 	Copyright 2019 The Tari Project
 
@@ -38,12 +38,14 @@
 	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-enum QRCodeScannerConstructor {
+struct PaperWalletDeeplink {
+    let seedWords: [String]
 
-    static func buildScene(expectedDataTypes: [QRCodeScannerModel.DataType], disabledDataTypes: [QRCodeScannerModel.DataType]) throws -> QRCodeScannerViewController {
-        let videoCaptureManager = VideoCaptureManager()
-        try videoCaptureManager.setupSession()
-        let model = QRCodeScannerModel(videoCaptureManager: videoCaptureManager, expectedDataTypes: expectedDataTypes, disabledDataTypes: disabledDataTypes)
-        return QRCodeScannerViewController(model: model, videoSession: videoCaptureManager.captureSession)
+    enum CodingKeys: String, CodingKey {
+        case seedWords = "seed_words"
     }
+}
+
+extension PaperWalletDeeplink: DeepLinkable {
+    static var type: DeeplinkType { .paperWallet }
 }

--- a/MobileWallet/Common/Managers/SeedWordsWalletRecoveryManager.swift
+++ b/MobileWallet/Common/Managers/SeedWordsWalletRecoveryManager.swift
@@ -1,0 +1,85 @@
+//  SeedWordsWalletRecoveryManager.swift
+
+/*
+	Package MobileWallet
+	Created by Adrian Truszczyński on 03/10/2024
+	Using Swift 5.0
+	Running on macOS 14.6
+
+	Copyright 2019 The Tari Project
+
+	Redistribution and use in source and binary forms, with or
+	without modification, are permitted provided that the
+	following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above
+	copyright notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	3. Neither the name of the copyright holder nor the names of
+	its contributors may be used to endorse or promote products
+	derived from this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+	CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+	CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+	OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+final class SeedWordsWalletRecoveryManager {
+
+    @Published private(set) var isEmptyWalletCreated: Bool = false
+    @Published private(set) var error: MessageModel?
+
+    func recover(seedWords: [String], customBaseNodeHex: String?, customBaseNodeAddress: String?) {
+
+        deleteWallet()
+
+        do {
+            try Tari.shared.restoreWallet(seedWords: seedWords)
+            try selectCustomBaseNode(hex: customBaseNodeHex, address: customBaseNodeAddress)
+            isEmptyWalletCreated = true
+        } catch let error as SeedWords.InternalError {
+            handle(seedWordsError: error)
+        } catch let error as WalletError {
+            handle(walletError: error)
+        } catch {
+            handleUnknownError()
+        }
+    }
+
+    func deleteWallet() {
+        Tari.shared.deleteWallet()
+        Tari.shared.canAutomaticalyReconnectWallet = false
+    }
+
+    private func selectCustomBaseNode(hex: String?, address: String?) throws {
+        guard let hex, let address else { return }
+        try Tari.shared.connection.addBaseNode(name: localized("restore_from_seed_words.custom_node_name"), hex: hex, address: address)
+    }
+
+    private func handle(seedWordsError: SeedWords.InternalError) {
+        error = ErrorMessageManager.errorModel(forError: seedWordsError)
+    }
+
+    private func handle(walletError: WalletError) {
+        let message = ErrorMessageManager.errorMessage(forError: walletError)
+        error = MessageModel(title: localized("restore_from_seed_words.error.title"), message: message, type: .error)
+    }
+
+    private func handleUnknownError() {
+        error = MessageModel(title: localized("restore_from_seed_words.error.title"), message: localized("restore_from_seed_words.error.description.unknown_error"), type: .error)
+    }
+}

--- a/MobileWallet/Screens/AdvancedSettings/Bridges/Custom Tor Bridges/CustomTorBridgesViewController.swift
+++ b/MobileWallet/Screens/AdvancedSettings/Bridges/Custom Tor Bridges/CustomTorBridgesViewController.swift
@@ -106,7 +106,7 @@ final class CustomTorBridgesViewController: SecureViewController<CustomTorBridge
     }
 
     private func showQRCodeScanner() {
-        AppRouter.presentQrCodeScanner(expectedDataTypes: [.torBridges]) { [weak self] data in
+        AppRouter.presentQrCodeScanner(expectedDataTypes: [.torBridges], disabledDataTypes: [.deeplink(.paperWallet)]) { [weak self] data in
             guard case let .bridges(bridges) = data else { return }
             self?.update(torBridges: bridges)
         }

--- a/MobileWallet/Screens/Contact Book/Add Contact/AddContactViewController.swift
+++ b/MobileWallet/Screens/Contact Book/Add Contact/AddContactViewController.swift
@@ -121,7 +121,7 @@ final class AddContactViewController: SecureViewController<AddContactView> {
     }
 
     private func showQRScanner() {
-        AppRouter.presentQrCodeScanner(expectedDataTypes: [.deeplink(.profile), .deeplink(.transactionSend)]) { [weak self] in
+        AppRouter.presentQrCodeScanner(expectedDataTypes: [.deeplink(.profile), .deeplink(.transactionSend)], disabledDataTypes: [.deeplink(.paperWallet)]) { [weak self] in
             self?.model.handle(qrCodeData: $0)
         }
     }

--- a/MobileWallet/Screens/Home/Home/HomeViewController.swift
+++ b/MobileWallet/Screens/Home/Home/HomeViewController.swift
@@ -157,7 +157,7 @@ final class HomeViewController: SecureViewController<HomeView> {
     }
 
     private func showQRCodeScanner() {
-        AppRouter.presentQrCodeScanner(expectedDataTypes: [], onExpectedDataScan: nil)
+        AppRouter.presentQrCodeScanner(expectedDataTypes: [], disabledDataTypes: [.deeplink(.paperWallet)], onExpectedDataScan: nil)
     }
 
     private func moveToTransactionList() {

--- a/MobileWallet/Screens/QR Code Scanner/QRCodeScannerViewController.swift
+++ b/MobileWallet/Screens/QR Code Scanner/QRCodeScannerViewController.swift
@@ -124,8 +124,7 @@ final class QRCodeScannerViewController: SecureViewController<QRCodeScannerView>
         case let .unexpectedData(action):
             dismissScene(onCompletion: action)
         case let .expectedData(data):
-            onExpectedDataScan?(data)
-            dismissScene(onCompletion: nil)
+            dismissScene(onCompletion: { [weak self] in self?.onExpectedDataScan?(data) })
         }
     }
 

--- a/MobileWallet/Screens/RestoreWallet/RestoreWalletViewController.swift
+++ b/MobileWallet/Screens/RestoreWallet/RestoreWalletViewController.swift
@@ -42,7 +42,7 @@ import UIKit
 import LocalAuthentication
 import Combine
 
-final class RestoreWalletViewController: SettingsParentTableViewController {
+final class RestoreWalletViewController: SettingsParentTableViewController, UITableViewDelegate, UITableViewDataSource, OverlayPresentable {
 
     private enum EndFlowAction {
         case none
@@ -52,12 +52,14 @@ final class RestoreWalletViewController: SettingsParentTableViewController {
 
     private let localAuth = LAContext()
 
+    private let model = RestoreWalletModel()
     private let pendingView = PendingView(title: localized("restore_pending_view.title"),
                                           definition: localized("restore_pending_view.description"))
     private let items: [SystemMenuTableViewCellItem] = [
         SystemMenuTableViewCellItem(title: RestoreCellTitle.iCloudRestore.rawValue),
         SystemMenuTableViewCellItem(title: RestoreCellTitle.dropboxRestore.rawValue),
-        SystemMenuTableViewCellItem(title: RestoreCellTitle.phraseRestore.rawValue)
+        SystemMenuTableViewCellItem(title: RestoreCellTitle.phraseRestore.rawValue),
+        SystemMenuTableViewCellItem(title: RestoreCellTitle.paperWalletRestore.rawValue)
     ]
 
     private var cancellables = Set<AnyCancellable>()
@@ -66,18 +68,37 @@ final class RestoreWalletViewController: SettingsParentTableViewController {
         case iCloudRestore
         case dropboxRestore
         case phraseRestore
+        case paperWalletRestore
 
         var rawValue: String {
             switch self {
             case .iCloudRestore: return localized("restore_wallet.item.iCloud_restore")
             case .dropboxRestore: return localized("restore_wallet.item.dropbox_restore")
             case .phraseRestore: return localized("restore_wallet.item.phrase_restore")
+            case .paperWalletRestore: return localized("restore_wallet.item.paper_wallet")
             }
         }
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupCallbacks()
+    }
+
+    // MARK: - Setups
+
+    private func setupCallbacks() {
+
+        model.$action
+            .compactMap { $0 }
+            .sink { [weak self] in self?.handle(action: $0) }
+            .store(in: &cancellables)
+
+        model.$error
+            .compactMap { $0 }
+            .sink { [weak self] in self?.handle(recoveryErrorMessage: $0) }
+            .store(in: &cancellables)
+
         tableView.delegate = self
         tableView.dataSource = self
     }
@@ -88,9 +109,22 @@ final class RestoreWalletViewController: SettingsParentTableViewController {
         let controller = PasswordVerificationViewController(variation: .restore, restoreWalletAction: onCompletion)
         navigationController?.pushViewController(controller, animated: true)
     }
-}
 
-extension RestoreWalletViewController: UITableViewDelegate, UITableViewDataSource {
+    private func showRecoveryOverlay() {
+
+        let overlay = SeedWordsRecoveryProgressViewController()
+
+        overlay.onSuccess = {
+            AppRouter.transitionToSplashScreen(isWalletConnected: true)
+        }
+
+        overlay.onFailure = { [weak self] in
+            self?.model.removeWallet()
+        }
+
+        show(overlay: overlay)
+    }
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         items.count
     }
@@ -116,6 +150,7 @@ extension RestoreWalletViewController: UITableViewDelegate, UITableViewDataSourc
         case .iCloudRestore: oniCloudRestoreAction()
         case .dropboxRestore: onDropboxRestoreAction()
         case .phraseRestore: onPhraseRestoreAction()
+        case .paperWalletRestore: onPaperWalletRestoreAction()
         }
     }
 
@@ -139,6 +174,13 @@ extension RestoreWalletViewController: UITableViewDelegate, UITableViewDataSourc
     private func onPhraseRestoreAction() {
         let viewController = RestoreWalletFromSeedsViewController()
         navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    private func onPaperWalletRestoreAction() {
+        let disabledDataTypes: [QRCodeScannerModel.DataType] = [.deeplink(.baseNodesAdd), .deeplink(.contacts), .deeplink(.profile), .deeplink(.transactionSend), .torBridges]
+        AppRouter.presentQrCodeScanner(expectedDataTypes: [.deeplink(.paperWallet)], disabledDataTypes: disabledDataTypes) { [weak self] in
+            self?.handle(qrCodeData: $0)
+        }
     }
 
     private func authenticateUserAndRestoreWallet(from service: BackupManager.Service) {
@@ -177,6 +219,21 @@ extension RestoreWalletViewController: UITableViewDelegate, UITableViewDataSourc
                 self?.restoreWallet(from: service, password: password)
             }
         }
+    }
+
+    private func showRecoveryFromPaperWalletPopUp() {
+
+        let model = PopUpDialogModel(
+            title: localized("restore_wallet.pop_up.paper_wallet.confirmation.title"),
+            message: localized("restore_wallet.pop_up.paper_wallet.confirmation.message"),
+            buttons: [
+                PopUpDialogButtonModel(title: localized("restore_wallet.pop_up.paper_wallet.confirmation.buttons.ok"), type: .normal, callback: { [weak self] in self?.model.confirmWalletRecovery() }),
+                PopUpDialogButtonModel(title: localized("restore_wallet.pop_up.paper_wallet.confirmation.buttons.cancel"), type: .text, callback: { [weak self] in self?.model.cancelWalletRecovery() })
+            ],
+            hapticType: .none
+        )
+
+        PopUpPresenter.showPopUp(model: model)
     }
 
     private func endFlow(action: EndFlowAction) {
@@ -229,6 +286,29 @@ extension RestoreWalletViewController: UITableViewDelegate, UITableViewDataSourc
         }
 
         endFlow(action: .none)
+    }
+
+    private func handle(action: RestoreWalletModel.Action) {
+        switch action {
+        case .showPaperWalletConfirmation:
+            showRecoveryFromPaperWalletPopUp()
+        case .showPaperWalletRecoveryProgress:
+            showRecoveryOverlay()
+        }
+    }
+
+    private func handle(recoveryErrorMessage: MessageModel) {
+        PopUpPresenter.show(message: recoveryErrorMessage)
+    }
+
+    private func handle(qrCodeData: QRCodeData) {
+        switch qrCodeData {
+        case let .deeplink(deeplink):
+            guard let deeplink = deeplink as? PaperWalletDeeplink else { return }
+            model.requestWalletRecovery(paperWalletDeeplink: deeplink)
+        case .bridges:
+            break
+        }
     }
 }
 

--- a/MobileWallet/Screens/Send/AddRecipient/AddRecipientViewController.swift
+++ b/MobileWallet/Screens/Send/AddRecipient/AddRecipientViewController.swift
@@ -167,7 +167,7 @@ final class AddRecipientViewController: UIViewController {
     // MARK: - Actions
 
     private func openScanner() {
-        AppRouter.presentQrCodeScanner(expectedDataTypes: [.deeplink(.transactionSend), .deeplink(.profile)]) { [weak self] in
+        AppRouter.presentQrCodeScanner(expectedDataTypes: [.deeplink(.transactionSend), .deeplink(.profile)], disabledDataTypes: [.deeplink(.paperWallet)]) { [weak self] in
             self?.model.handle(qrCodeData: $0)
         }
     }

--- a/MobileWallet/en.lproj/Localizable.strings
+++ b/MobileWallet/en.lproj/Localizable.strings
@@ -411,6 +411,11 @@
 "restore_wallet.item.iCloud_restore" = "Restore with iCloud";
 "restore_wallet.item.dropbox_restore" = "Restore with Dropbox";
 "restore_wallet.item.phrase_restore" = "Restore with recovery phrase";
+"restore_wallet.item.paper_wallet" = "Restore from paper wallet";
+"restore_wallet.pop_up.paper_wallet.confirmation.title" = "Paper Wallet Detected";
+"restore_wallet.pop_up.paper_wallet.confirmation.message" = "You’ve scanned a paper wallet!\nWhat would you like to do?";
+"restore_wallet.pop_up.paper_wallet.confirmation.buttons.ok" = "Restore the wallet";
+"restore_wallet.pop_up.paper_wallet.confirmation.buttons.cancel" = "Don’t restore right now";
 
 /* PasswordVerification view */
 "password_verification.title" = "Security";


### PR DESCRIPTION
- Added new recovery option. Now user can recover paper wallet and use it as his main wallet.
- Updated QR code scanner, now it can handle paper wallet deep links and exclude data types from triggering the deep link handler.
![Simulator Screenshot - iPhone 15 Pro - 2024-10-03 at 11 26 09](https://github.com/user-attachments/assets/5665e2d2-33fb-43bc-b38f-f7c771c411eb)
