### PR TITLE
Disabling/Removing Base Node Switching

### DIFF
--- a/MobileWallet/Libraries/TariLib/Core/Services/TariConnectionService.swift
+++ b/MobileWallet/Libraries/TariLib/Core/Services/TariConnectionService.swift
@@ -50,19 +50,12 @@ final class TariConnectionService: CoreTariService {
         services.validation.reset()
         do {
             let result = try walletManager.set(baseNodePeer: baseNode.makePublicKey(), address: baseNode.address)
-            NetworkManager.shared.selectedBaseNode = baseNode
             return result
         } catch FFIWalletHandler.GeneralError.unableToCreateWallet {
-            NetworkManager.shared.selectedBaseNode = baseNode
             return false
         } catch {
             throw error
         }
-    }
-
-    @discardableResult func selectCurrentNode() throws -> Bool {
-        guard let selectedBaseNode = NetworkManager.shared.selectedBaseNode else { return false }
-        return try select(baseNode: selectedBaseNode)
     }
 
     func addBaseNode(name: String, hex: String, address: String?) throws {

--- a/MobileWallet/Libraries/TariLib/Core/Services/TariRecoveryService.swift
+++ b/MobileWallet/Libraries/TariLib/Core/Services/TariRecoveryService.swift
@@ -70,14 +70,7 @@ final class TariRecoveryService: CoreTariService {
     // MARK: - Actions
 
     func startRecovery(recoveredOutputMessage: String) throws -> Bool {
-
-        var selectedBaseNode = NetworkManager.shared.selectedBaseNode
-
-        if selectedBaseNode == nil {
-            selectedBaseNode = try services.connection.defaultBaseNodePeers().randomElement()
-        }
-
-        guard let selectedBaseNode else { return false }
+        guard let selectedBaseNode = try services.connection.defaultBaseNodePeers().randomElement() else { return false }
         return try walletManager.startRecovery(baseNodePublicKey: selectedBaseNode.makePublicKey(), recoveredOutputMessage: recoveredOutputMessage)
     }
 

--- a/MobileWallet/Libraries/TariLib/Wrappers/Utils/Network/NetworkManager.swift
+++ b/MobileWallet/Libraries/TariLib/Wrappers/Utils/Network/NetworkManager.swift
@@ -55,11 +55,6 @@ final class NetworkManager {
 
     var defaultBaseNodes: [BaseNode] { (try? Tari.shared.wallet(.main).connection.defaultBaseNodePeers()) ?? [] }
 
-    var selectedBaseNode: BaseNode? {
-        get { settings.selectedBaseNode }
-        set { update(settings: settings.update(selectedBaseNode: newValue)) }
-    }
-
     var customBaseNodes: [BaseNode] {
         get { settings.customBaseNodes }
         set { update(settings: settings.update(customBaseNodes: newValue)) }
@@ -76,7 +71,7 @@ final class NetworkManager {
         let allSettings = GroupUserDefaults.networksSettings ?? []
 
         guard let existingSettings = allSettings.first(where: { $0.name == selectedNetwork.name }) else {
-            let newSettings = NetworkSettings(name: selectedNetwork.name, selectedBaseNode: nil, customBaseNodes: [], blockHeight: 0)
+            let newSettings = NetworkSettings(name: selectedNetwork.name, customBaseNodes: [], blockHeight: 0)
             update(settings: newSettings)
             return newSettings
         }

--- a/MobileWallet/Libraries/TariLib/Wrappers/Utils/Network/NetworkSettings.swift
+++ b/MobileWallet/Libraries/TariLib/Wrappers/Utils/Network/NetworkSettings.swift
@@ -41,7 +41,6 @@
 struct NetworkSettings: Codable, Equatable {
 
     let name: String
-    let selectedBaseNode: BaseNode?
     let customBaseNodes: [BaseNode]
     let blockHeight: UInt64
 
@@ -49,7 +48,6 @@ struct NetworkSettings: Codable, Equatable {
 }
 
 extension NetworkSettings {
-    func update(selectedBaseNode: BaseNode?) -> Self { Self(name: name, selectedBaseNode: selectedBaseNode, customBaseNodes: customBaseNodes, blockHeight: blockHeight) }
-    func update(customBaseNodes: [BaseNode]) -> Self { Self(name: name, selectedBaseNode: selectedBaseNode, customBaseNodes: customBaseNodes, blockHeight: blockHeight) }
-    func update(blockHeight: UInt64) -> Self { Self(name: name, selectedBaseNode: selectedBaseNode, customBaseNodes: customBaseNodes, blockHeight: blockHeight) }
+    func update(customBaseNodes: [BaseNode]) -> Self { Self(name: name, customBaseNodes: customBaseNodes, blockHeight: blockHeight) }
+    func update(blockHeight: UInt64) -> Self { Self(name: name, customBaseNodes: customBaseNodes, blockHeight: blockHeight) }
 }

--- a/MobileWallet/Screens/AdvancedSettings/SelectBaseNode/SelectBaseNodeModel.swift
+++ b/MobileWallet/Screens/AdvancedSettings/SelectBaseNode/SelectBaseNodeModel.swift
@@ -65,11 +65,6 @@ final class SelectBaseNodeModel {
 
     // MARK: - Setups
 
-    private func updateSelectedNodeIndex() {
-        let selectedBaseNode = NetworkManager.shared.selectedBaseNode
-        selectedNodeIndex = avaiableNodes.firstIndex { $0.peer == selectedBaseNode?.peer }
-    }
-
     private func updateViewModelNodes() {
         nodes = avaiableNodes
             .enumerated()
@@ -88,7 +83,6 @@ final class SelectBaseNodeModel {
     // MARK: - Actions
 
     func refreshData() {
-        updateSelectedNodeIndex()
         updateViewModelNodes()
     }
 

--- a/MobileWallet/Screens/AppEntry/Splash/SplashViewModel.swift
+++ b/MobileWallet/Screens/AppEntry/Splash/SplashViewModel.swift
@@ -170,11 +170,7 @@ final class SplashViewModel {
 
                 try await connectToWallet(isWalletConnected: isWalletConnected)
                 isWalletConnected = false
-
                 status = StatusModel(status: .success, statusRepresentation: statusRepresentation)
-
-                let randomBaseNode = try NetworkManager.shared.randomBaseNode()
-                try Tari.shared.wallet(.main).connection.select(baseNode: randomBaseNode)
             } catch {
                 self.handle(error: error)
             }

--- a/MobileWallet/Screens/Settings/SettingsViewController.swift
+++ b/MobileWallet/Screens/Settings/SettingsViewController.swift
@@ -129,7 +129,6 @@ final class SettingsViewController: SettingsParentTableViewController {
         SystemMenuTableViewCellItem(icon: .Icons.Settings.bluetooth, title: SettingsItemTitle.bluetoothConfiguration.rawValue),
         SystemMenuTableViewCellItem(icon: .Icons.Settings.bridgeConfig, title: SettingsItemTitle.torBridgeConfiguration.rawValue),
         SystemMenuTableViewCellItem(icon: .Icons.Settings.network, title: SettingsItemTitle.selectNetwork.rawValue),
-        SystemMenuTableViewCellItem(icon: .Icons.Settings.baseNode, title: SettingsItemTitle.selectBaseNode.rawValue),
         SystemMenuTableViewCellItem(icon: .Icons.Settings.delete, title: SettingsItemTitle.deleteWallet.rawValue, isDestructive: true)
     ]
 
@@ -402,8 +401,6 @@ extension SettingsViewController: UITableViewDelegate, UITableViewDataSource {
             case 4:
                 onSelectNetworkAction()
             case 5:
-                onSelectBaseNodeAction()
-            case 6:
                 onDeleteWalletAction()
             default:
                 break


### PR DESCRIPTION
- Removed base node switching functionality from the App
- Hidden "select base node" button on settings screen to make that settings group unaccessible for the users.