### PR TITLE
Handle non-interactive addresses (#1173)

### DIFF
--- a/MobileWallet/Libraries/TariLib/Core/FFI/Keys/TariAddress.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFI/Keys/TariAddress.swift
@@ -203,6 +203,14 @@ extension TariAddress.Features {
             .filter { value.flag(bitmask: $0.rawValue) }
             .map(\.name)
     }
+    
+    func isOnesided() -> Bool {
+        return value.flag(bitmask: Feature.oneSided.rawValue)
+    }
+        
+    func isInteractive() -> Bool {
+        return value.flag(bitmask: Feature.interactive.rawValue)
+    }
 }
 
 extension TariAddress.Features.Feature {

--- a/MobileWallet/Libraries/TariLib/Core/FFI/Keys/TariAddressComponents.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFI/Keys/TariAddressComponents.swift
@@ -52,7 +52,10 @@ struct TariAddressComponents {
 
     let fullRaw: String
     let fullEmoji: String
+    
     let isUnknownAddress: Bool
+    let isOnesidedAddress: Bool
+    let isInteractiveAddress: Bool
 }
 
 extension TariAddressComponents {
@@ -85,5 +88,7 @@ extension TariAddressComponents {
         fullRaw = [networkBase58, featuresBase58, addressBase58].joined()
         fullEmoji = try address.emojis
         isUnknownAddress = try address.spendKey.byteVector.bytes.first { $0 != 0 } == nil
+        isOnesidedAddress = try address.features.isOnesided()
+        isInteractiveAddress = try address.features.isInteractive()
     }
 }

--- a/MobileWallet/Libraries/TariLib/Wrappers/Utils/Network/NetworkManager.swift
+++ b/MobileWallet/Libraries/TariLib/Wrappers/Utils/Network/NetworkManager.swift
@@ -49,7 +49,7 @@ final class NetworkManager {
     // MARK: - Properties
 
     static let shared = NetworkManager()
-    private static var defaultNetwork: TariNetwork { .esmeralda }
+    private static var defaultNetwork: TariNetwork { .nextnet }
 
     @Published var selectedNetwork: TariNetwork
 

--- a/MobileWallet/Libraries/TariLib/Wrappers/Utils/Network/TariNetwork.swift
+++ b/MobileWallet/Libraries/TariLib/Wrappers/Utils/Network/TariNetwork.swift
@@ -49,7 +49,7 @@ struct TariNetwork {
 
 extension TariNetwork {
 
-    static var all: [TariNetwork] { [esmeralda].compactMap { $0 } }
+    static var all: [TariNetwork] { [nextnet].compactMap { $0 } }
 
     static var stagenet: Self {
         makeNetwork(

--- a/MobileWallet/Screens/Send/AddAmount/AddAmountViewController.swift
+++ b/MobileWallet/Screens/Send/AddAmount/AddAmountViewController.swift
@@ -694,6 +694,11 @@ extension AddAmountViewController {
         oneSidedPaymentHelpButton.onTap = {
             PopUpPresenter.show(message: MessageModel(title: localized("add_amount.pop_up.one_sided_payment.title"), message: localized("add_amount.pop_up.one_sided_payment.description"), type: .normal))
         }
+        
+        if paymentInfo.addressComponents.isOnesidedAddress && !paymentInfo.addressComponents.isInteractiveAddress {
+            oneSidedPaymentSwitch.isUserInteractionEnabled = false
+            oneSidedPaymentSwitch.isOn = true
+        }
     }
 
     private func setupCallbacks() {

--- a/MobileWallet/UIElements/TabBar/MenuTabBarController.swift
+++ b/MobileWallet/UIElements/TabBar/MenuTabBarController.swift
@@ -114,11 +114,11 @@ extension MenuTabBarController: UITabBarControllerDelegate {
     }
 
     func tabBarController(_ tabBarController: UITabBarController, animationControllerForTransitionFrom fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return Transition(viewControllers: tabBarController.viewControllers)
+        return TabBarTransition(viewControllers: tabBarController.viewControllers)
     }
 }
 
-private class Transition: NSObject, UIViewControllerAnimatedTransitioning {
+private class TabBarTransition: NSObject, UIViewControllerAnimatedTransitioning {
     let viewControllers: [UIViewController]?
     let transitionDuration: Double = CATransaction.animationDuration()
 

--- a/Podfile
+++ b/Podfile
@@ -4,11 +4,11 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'MobileWallet' do
-  pod 'Tor', '408.12.1'
+  pod 'Tor', '408.12.2'
   pod 'lottie-ios', '3.2.3'
   pod 'SwiftEntryKit', '2.0.0'
   pod 'ReachabilitySwift', '5.0.0'
-  pod 'Sentry', '8.14.2'
+  pod 'Sentry', '8.39.0'
   pod 'SwiftKeychainWrapper', '3.4.0'
   pod 'Giphy', '2.1.22'
   pod 'IPtProxy', '3.3.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,21 +17,18 @@ PODS:
   - libwebp/webp (1.2.3)
   - lottie-ios (3.2.3)
   - ReachabilitySwift (5.0.0)
-  - Sentry (8.14.2):
-    - Sentry/Core (= 8.14.2)
-    - SentryPrivate (= 8.14.2)
-  - Sentry/Core (8.14.2):
-    - SentryPrivate (= 8.14.2)
-  - SentryPrivate (8.14.2)
+  - Sentry (8.39.0):
+    - Sentry/Core (= 8.39.0)
+  - Sentry/Core (8.39.0)
   - SwiftEntryKit (2.0.0)
   - SwiftKeychainWrapper (3.4.0)
   - SwiftyDropbox (8.2.1):
     - Alamofire (~> 5.4.3)
   - TariCommon (0.2.0)
-  - Tor (408.12.1):
-    - Tor/CTor (= 408.12.1)
-  - Tor/Core (408.12.1)
-  - Tor/CTor (408.12.1):
+  - Tor (408.12.2):
+    - Tor/CTor (= 408.12.2)
+  - Tor/Core (408.12.2)
+  - Tor/CTor (408.12.2):
     - Tor/Core
   - YatLib (0.4.1):
     - TariCommon (~> 0.2.0)
@@ -43,12 +40,12 @@ DEPENDENCIES:
   - IPtProxy (= 3.3.0)
   - lottie-ios (= 3.2.3)
   - ReachabilitySwift (= 5.0.0)
-  - Sentry (= 8.14.2)
+  - Sentry (= 8.39.0)
   - SwiftEntryKit (= 2.0.0)
   - SwiftKeychainWrapper (= 3.4.0)
   - SwiftyDropbox (= 8.2.1)
   - TariCommon (= 0.2.0)
-  - Tor (= 408.12.1)
+  - Tor (= 408.12.2)
   - YatLib (= 0.4.1)
   - Zip (= 2.1.2)
 
@@ -63,7 +60,6 @@ SPEC REPOS:
     - lottie-ios
     - ReachabilitySwift
     - Sentry
-    - SentryPrivate
     - SwiftEntryKit
     - SwiftKeychainWrapper
     - SwiftyDropbox
@@ -81,16 +77,15 @@ SPEC CHECKSUMS:
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
   lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  Sentry: e0ea366f95ebb68f26d6030d8c22d6b2e6d23dd0
-  SentryPrivate: 949a21fa59872427edc73b524c3ec8456761d97f
+  Sentry: e92ec378be400dbb7f4065ff152d0f362ba8b4ba
   SwiftEntryKit: 61b5fa36f34a97dd8013e48a7345bc4c4720be9a
   SwiftKeychainWrapper: 6fc49fbf7d4a6b0772917acb0e53a1639f6078d6
   SwiftyDropbox: f6c55aae36c4ea944fe6b35f807c19897f78b09b
   TariCommon: 2c8bb97359f59d6b302d2e96c191ff95931da8ac
-  Tor: 958cbe68eef90659339403e40e20d7610a9456dd
+  Tor: 19907fc430953434a233c7532166d6409b9d509b
   YatLib: dda2cfe9e47790f27a13074ea815eac19a919043
   Zip: b3fef584b147b6e582b2256a9815c897d60ddc67
 
-PODFILE CHECKSUM: dc384166ada1bb7778b3b6cec7e0de637592c8db
+PODFILE CHECKSUM: 154a2c1d1be3da085e9e5637dba213d68731bf8b
 
 COCOAPODS: 1.15.2

--- a/dependencies.env
+++ b/dependencies.env
@@ -1,1 +1,1 @@
-FFI_VERSION="1.7.0-pre.3"
+FFI_VERSION="1.7.0-rc.1"


### PR DESCRIPTION
Disabled the possibility to modify transaction type for non-interactive addresses.

Additionally:
- Bumped Sentry pod to 8.39 and Tor 408.12.2 for the project to build on newer environments
- Fixed naming collision for tabBar transition
- Switched network to NextNet