### PR TITLE
Bump ffi library version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ xcuserdata/
 *.xccheckout
 *.xcscmblueprint
 *.hhea.xml
+GoogleService-Info.plist
 
 ## Obj-C/Swift specific
 *.hmap

--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -4125,7 +4125,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 0.31.0;
+				MARKETING_VERSION = 0.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tari.wallet;
 				PRODUCT_NAME = "Tari Aurora";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4158,7 +4158,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 0.31.0;
+				MARKETING_VERSION = 0.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tari.wallet;
 				PRODUCT_NAME = "Tari Aurora";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -4125,7 +4125,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 0.31.1;
+				MARKETING_VERSION = 0.31.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tari.wallet;
 				PRODUCT_NAME = "Tari Aurora";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4158,7 +4158,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 0.31.1;
+				MARKETING_VERSION = 0.31.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tari.wallet;
 				PRODUCT_NAME = "Tari Aurora";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MobileWallet.xcodeproj/project.pbxproj
+++ b/MobileWallet.xcodeproj/project.pbxproj
@@ -4125,7 +4125,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 0.30.1;
+				MARKETING_VERSION = 0.31.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tari.wallet;
 				PRODUCT_NAME = "Tari Aurora";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4158,7 +4158,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 0.30.1;
+				MARKETING_VERSION = 0.31.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tari.wallet;
 				PRODUCT_NAME = "Tari Aurora";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MobileWallet/Common/Managers/MigrationManager.swift
+++ b/MobileWallet/Common/Managers/MigrationManager.swift
@@ -45,7 +45,7 @@ enum MigrationManager {
     private static let esmeraldaMinValidVersion = "1.6.0-pre.0"
     private static let nextNetMinValidVersion = "1.4.1-rc.0"
 
-    private static var minValidVersion: String { esmeraldaMinValidVersion }
+    private static var minValidVersion: String { nextNetMinValidVersion }
 
     // MARK: - Actions
 
@@ -69,8 +69,9 @@ enum MigrationManager {
         let version = await fetchDBVersion()
 
         if let version {
-            let isValid = VersionValidator.compare(version, isHigherOrEqualTo: minValidVersion)
-            Logger.log(message: "Min. Valid Wallet Version: \(minValidVersion), Local Wallet Version: \(version), isValid: \(isValid)", domain: .general, level: .info)
+            let min = minValidVersion
+            let isValid = VersionValidator.compare(version, isHigherOrEqualTo: min)
+            Logger.log(message: "Min. Valid Wallet Version: \(min), Local Wallet Version: \(version), isValid: \(isValid)", domain: .general, level: .info)
             return isValid
         } else {
             Logger.log(message: "Unable to get wallet version", domain: .general, level: .info)

--- a/MobileWallet/Common/Managers/MigrationManager.swift
+++ b/MobileWallet/Common/Managers/MigrationManager.swift
@@ -43,7 +43,7 @@ enum MigrationManager {
     // MARK: - Properties
 
     private static let esmeraldaMinValidVersion = "1.6.0-pre.0"
-    private static let nextNetMinValidVersion = "1.4.1-rc.0"
+    private static let nextNetMinValidVersion = "1.13.0-rc.0"
 
     private static var minValidVersion: String { nextNetMinValidVersion }
 

--- a/MobileWallet/Common/Managers/WalletTransactionsManager.swift
+++ b/MobileWallet/Common/Managers/WalletTransactionsManager.swift
@@ -117,9 +117,9 @@ final class WalletTransactionsManager {
                 toAddress: tariAddress,
                 amount: amount.rawValue,
                 feePerGram: feePerGram.rawValue,
-                message: isOneSidedPayment ? "" : message,
+                message: message,
                 isOneSidedPayment: isOneSidedPayment,
-                paymentID: isOneSidedPayment ? message : ""
+                paymentID: message
             )
 
             guard !isOneSidedPayment else {

--- a/MobileWallet/Common/Tools/VersionValidator.swift
+++ b/MobileWallet/Common/Tools/VersionValidator.swift
@@ -40,7 +40,7 @@
 
 enum VersionValidator {
     static func compare(_ firstVersion: String, isHigherOrEqualTo secondVersion: String) -> Bool {
-        Version(rawVersion: firstVersion) >= Version(rawVersion: secondVersion)
+        return Version(rawVersion: firstVersion) >= Version(rawVersion: secondVersion)
     }
 }
 
@@ -95,8 +95,8 @@ private struct Version: Comparable {
 
         let result: Bool? = zip(firstComponents, secondComponents)
             .compactMap {
-                guard $0 != $1 else { return nil }
-                return $0 < $1
+                guard let left = Int($0), let right = Int($1) else { return false }
+                return left < right
             }
             .first
 

--- a/MobileWallet/Info.plist
+++ b/MobileWallet/Info.plist
@@ -38,9 +38,7 @@
 			<key>CFBundleURLName</key>
 			<string>Dropbox</string>
 			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>db-wla963yxne31xe6</string>
-			</array>
+			<dict/>
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>

--- a/MobileWallet/Info.plist
+++ b/MobileWallet/Info.plist
@@ -38,7 +38,9 @@
 			<key>CFBundleURLName</key>
 			<string>Dropbox</string>
 			<key>CFBundleURLSchemes</key>
-			<dict/>
+			<array>
+				<string>db-wla963yxne31xe6</string>
+			</array>
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>

--- a/MobileWallet/Libraries/TariLib/Core/FFI/Keys/TariAddress.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFI/Keys/TariAddress.swift
@@ -203,11 +203,11 @@ extension TariAddress.Features {
             .filter { value.flag(bitmask: $0.rawValue) }
             .map(\.name)
     }
-    
+
     func isOnesided() -> Bool {
         return value.flag(bitmask: Feature.oneSided.rawValue)
     }
-        
+
     func isInteractive() -> Bool {
         return value.flag(bitmask: Feature.interactive.rawValue)
     }

--- a/MobileWallet/Libraries/TariLib/Core/FFI/Keys/TariAddressComponents.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFI/Keys/TariAddressComponents.swift
@@ -52,7 +52,7 @@ struct TariAddressComponents {
 
     let fullRaw: String
     let fullEmoji: String
-    
+
     let isUnknownAddress: Bool
     let isOnesidedAddress: Bool
     let isInteractiveAddress: Bool

--- a/MobileWallet/Libraries/TariLib/Core/FFI/Transactions/Completed/CompletedTransaction.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFI/Transactions/Completed/CompletedTransaction.swift
@@ -115,7 +115,7 @@ final class CompletedTransaction: Transaction {
         get throws {
             var errorCode: Int32 = -1
             let errorCodePointer = PointerHandler.pointer(for: &errorCode)
-            let result = completed_transaction_get_message(pointer, errorCodePointer)
+            let result = completed_transaction_get_payment_id(pointer, errorCodePointer)
 
             guard errorCode == 0, let cString = result else { throw WalletError(code: errorCode) }
             return String(cString: cString)

--- a/MobileWallet/Libraries/TariLib/Core/FFI/Transactions/Pending Inbound/PendingInboundTransaction.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFI/Transactions/Pending Inbound/PendingInboundTransaction.swift
@@ -74,7 +74,7 @@ final class PendingInboundTransaction: Transaction {
         get throws {
             var errorCode: Int32 = -1
             let errorCodePointer = PointerHandler.pointer(for: &errorCode)
-            let result = pending_inbound_transaction_get_message(pointer, errorCodePointer)
+            let result = pending_inbound_transaction_get_payment_id(pointer, errorCodePointer)
 
             guard errorCode == 0, let cString = result else { throw WalletError(code: errorCode) }
             return String(cString: cString)

--- a/MobileWallet/Libraries/TariLib/Core/FFI/Transactions/Pending Outbound/PendingOutboundTransaction.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFI/Transactions/Pending Outbound/PendingOutboundTransaction.swift
@@ -85,7 +85,7 @@ final class PendingOutboundTransaction: Transaction {
         get throws {
             var errorCode: Int32 = -1
             let errorCodePointer = PointerHandler.pointer(for: &errorCode)
-            let result = pending_outbound_transaction_get_message(pointer, errorCodePointer)
+            let result = pending_outbound_transaction_get_payment_id(pointer, errorCodePointer)
 
             guard errorCode == 0, let cString = result else { throw WalletError(code: errorCode) }
             return String(cString: cString)

--- a/MobileWallet/Libraries/TariLib/Core/FFIWalletHandler.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFIWalletHandler.swift
@@ -346,7 +346,7 @@ final class FFIWalletHandler {
 
         var errorCode: Int32 = -1
         let errorCodePointer = PointerHandler.pointer(for: &errorCode)
-        
+
         let result = wallet_send_transaction(wallet.pointer, address.pointer, amount, nil, feePerGram, isOneSidedPayment, message, errorCodePointer)
 
         guard errorCode == 0 else { throw WalletError(code: errorCode) }

--- a/MobileWallet/Libraries/TariLib/Core/FFIWalletHandler.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFIWalletHandler.swift
@@ -347,17 +347,6 @@ final class FFIWalletHandler {
         var errorCode: Int32 = -1
         let errorCodePointer = PointerHandler.pointer(for: &errorCode)
         
-        /*
-         unsigned long long wallet_send_transaction(struct TariWallet *wallet,
-                                                    TariWalletAddress *destination,
-                                                    unsigned long long amount,
-                                                    struct TariVector *commitments,
-                                                    unsigned long long fee_per_gram,
-                                                    bool one_sided,
-                                                    const char *payment_id_string,
-                                                    int *error_out);
-         
-         */
         let result = wallet_send_transaction(wallet.pointer, address.pointer, amount, nil, feePerGram, isOneSidedPayment, message, errorCodePointer)
 
         guard errorCode == 0 else { throw WalletError(code: errorCode) }

--- a/MobileWallet/Libraries/TariLib/Core/FFIWalletHandler.swift
+++ b/MobileWallet/Libraries/TariLib/Core/FFIWalletHandler.swift
@@ -346,7 +346,19 @@ final class FFIWalletHandler {
 
         var errorCode: Int32 = -1
         let errorCodePointer = PointerHandler.pointer(for: &errorCode)
-        let result = wallet_send_transaction(wallet.pointer, address.pointer, amount, nil, feePerGram, message, isOneSidedPayment, paymentID, errorCodePointer)
+        
+        /*
+         unsigned long long wallet_send_transaction(struct TariWallet *wallet,
+                                                    TariWalletAddress *destination,
+                                                    unsigned long long amount,
+                                                    struct TariVector *commitments,
+                                                    unsigned long long fee_per_gram,
+                                                    bool one_sided,
+                                                    const char *payment_id_string,
+                                                    int *error_out);
+         
+         */
+        let result = wallet_send_transaction(wallet.pointer, address.pointer, amount, nil, feePerGram, isOneSidedPayment, message, errorCodePointer)
 
         guard errorCode == 0 else { throw WalletError(code: errorCode) }
         return result

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenCollectionView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenCollectionView.swift
@@ -187,10 +187,12 @@ final class TokenCollectionView: DynamicThemeView {
         }
 
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(onTapOutsideAction))
-
+        let longPressGestureRecogninzer = UILongPressGestureRecognizer(target: self, action: #selector(onLongPressAction))
+        
         collectionView.dataSource = dataSource
         collectionView.delegate = self
         collectionView.backgroundView?.addGestureRecognizer(tapGestureRecognizer)
+        collectionView.backgroundView?.addGestureRecognizer(longPressGestureRecogninzer)
 
         self.dataSource = dataSource
     }
@@ -246,6 +248,10 @@ final class TokenCollectionView: DynamicThemeView {
         textField?.becomeFirstResponder()
     }
 
+    @objc private func onLongPressAction() {
+        let inputView = collectionView.subviews.first { $0 is TokenInputView }
+        (inputView as? TokenInputView)?.triggerSystemTextMenu()
+    }
     // MARK: - First Responder
 
     override func resignFirstResponder() -> Bool {

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenCollectionView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenCollectionView.swift
@@ -188,7 +188,7 @@ final class TokenCollectionView: DynamicThemeView {
 
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(onTapOutsideAction))
         let longPressGestureRecogninzer = UILongPressGestureRecognizer(target: self, action: #selector(onLongPressAction))
-        
+
         collectionView.dataSource = dataSource
         collectionView.delegate = self
         collectionView.backgroundView?.addGestureRecognizer(tapGestureRecognizer)

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenInputView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenInputView.swift
@@ -53,6 +53,9 @@ final class TokenInputView: DynamicThemeCollectionCell {
         view.autocorrectionType = .no
         view.autocapitalizationType = .none
         view.spellCheckingType = .no
+        view.isSecureTextEntry = false
+        view.isUserInteractionEnabled = true
+        
         return view
     }()
 
@@ -135,6 +138,14 @@ final class TokenInputView: DynamicThemeCollectionCell {
     override func resignFirstResponder() -> Bool {
         onEndEditing?(textField.text ?? "")
         return textField.resignFirstResponder()
+    }
+    
+    public func triggerSystemTextMenu() -> Void {
+        let menuController = UIMenuController.shared
+        self.becomeFirstResponder() // Ensure the view is first responder
+
+        // Position the menu over the entire view for example:
+        menuController.showMenu(from: self, rect: self.bounds)
     }
 }
 

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenInputView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenInputView.swift
@@ -55,7 +55,7 @@ final class TokenInputView: DynamicThemeCollectionCell {
         view.spellCheckingType = .no
         view.isSecureTextEntry = false
         view.isUserInteractionEnabled = true
-        
+
         return view
     }()
 
@@ -139,8 +139,8 @@ final class TokenInputView: DynamicThemeCollectionCell {
         onEndEditing?(textField.text ?? "")
         return textField.resignFirstResponder()
     }
-    
-    public func triggerSystemTextMenu() -> Void {
+
+    public func triggerSystemTextMenu() {
         let menuController = UIMenuController.shared
         self.becomeFirstResponder() // Ensure the view is first responder
 

--- a/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenView.swift
+++ b/MobileWallet/Screens/RestoreWalletFromSeeds/Views/TokenView.swift
@@ -124,7 +124,6 @@ final class TokenView: DynamicThemeCollectionCell {
             deleteIconView.heightAnchor.constraint(equalToConstant: 14.0),
             deleteIconView.widthAnchor.constraint(equalToConstant: 14.0)
         ]
-
         NSLayoutConstraint.activate(constraints)
     }
 

--- a/MobileWallet/Screens/Send/AddAmount/AddAmountViewController.swift
+++ b/MobileWallet/Screens/Send/AddAmount/AddAmountViewController.swift
@@ -445,9 +445,9 @@ final class AddAmountViewController: DynamicThemeViewController {
         
         if paymentInfo.note != nil {
             let paymentInfo = PaymentInfo(addressComponents: paymentInfo.addressComponents, alias: paymentInfo.alias, yatID: paymentInfo.yatID, amount: paymentInfo.amount, feePerGram: paymentInfo.feePerGram, note: paymentInfo.note)
-            TransactionProgressPresenter.showTransactionProgress(presenter: self, paymentInfo: paymentInfo, isOneSidedPayment: oneSidedPaymentSwitch.isOn)
+            TransactionProgressPresenter.showTransactionProgress(presenter: self, paymentInfo: paymentInfo, isOneSidedPayment: true)
         }else {
-            let controller = AddNoteViewController(paymentInfo: paymentInfo, isOneSidedPayment: oneSidedPaymentSwitch.isOn)
+            let controller = AddNoteViewController(paymentInfo: paymentInfo, isOneSidedPayment: true)
             navigationController?.pushViewController(controller, animated: true)
         }
     }
@@ -709,6 +709,8 @@ extension AddAmountViewController {
             oneSidedPaymentSwitch.isUserInteractionEnabled = false
             oneSidedPaymentSwitch.isOn = true
         }
+        
+        oneSidedPaymentStackView.isHidden = true
     }
 
     private func setupCallbacks() {

--- a/MobileWallet/Screens/Send/AddNote/AddNoteViewController.swift
+++ b/MobileWallet/Screens/Send/AddNote/AddNoteViewController.swift
@@ -584,7 +584,7 @@ final class TariGiphyTheme: GPHTheme {
         self.type = .light
     }
 
-    override var textFieldFont: UIFont? {
+    var textFieldFont: UIFont? {
         return Theme.shared.fonts.searchContactsInputBoxText
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ target 'MobileWallet' do
   pod 'ReachabilitySwift', '5.0.0'
   pod 'Sentry', '8.39.0'
   pod 'SwiftKeychainWrapper', '3.4.0'
-  pod 'Giphy', '2.1.22'
+  pod 'Giphy', '2.2.11'
   pod 'IPtProxy', '3.3.0'
   pod 'Zip', '2.1.2'
   pod 'SwiftyDropbox', '8.2.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,18 +3,21 @@ PODS:
   - Base58Swift (2.1.10):
     - BigInt (~> 5.0.0)
   - BigInt (5.0.0)
-  - Giphy (2.1.22):
+  - Giphy (2.2.11):
     - libwebp
   - IPtProxy (3.3.0)
-  - libwebp (1.2.3):
-    - libwebp/demux (= 1.2.3)
-    - libwebp/mux (= 1.2.3)
-    - libwebp/webp (= 1.2.3)
-  - libwebp/demux (1.2.3):
+  - libwebp (1.5.0):
+    - libwebp/demux (= 1.5.0)
+    - libwebp/mux (= 1.5.0)
+    - libwebp/sharpyuv (= 1.5.0)
+    - libwebp/webp (= 1.5.0)
+  - libwebp/demux (1.5.0):
     - libwebp/webp
-  - libwebp/mux (1.2.3):
+  - libwebp/mux (1.5.0):
     - libwebp/demux
-  - libwebp/webp (1.2.3)
+  - libwebp/sharpyuv (1.5.0)
+  - libwebp/webp (1.5.0):
+    - libwebp/sharpyuv
   - lottie-ios (3.2.3)
   - ReachabilitySwift (5.0.0)
   - Sentry (8.39.0):
@@ -36,7 +39,7 @@ PODS:
 
 DEPENDENCIES:
   - Base58Swift (= 2.1.10)
-  - Giphy (= 2.1.22)
+  - Giphy (= 2.2.11)
   - IPtProxy (= 3.3.0)
   - lottie-ios (= 3.2.3)
   - ReachabilitySwift (= 5.0.0)
@@ -72,9 +75,9 @@ SPEC CHECKSUMS:
   Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
   Base58Swift: 53d551f0b33d9478fa63b3445e453a772d6b31a7
   BigInt: 74b4d88367b0e819d9f77393549226d36faeb0d8
-  Giphy: 6757d929878ef45f70ed62a02a2c9a03994e7b6c
+  Giphy: faa396040488ce71a33c4c090a2fa71f868e389e
   IPtProxy: 2136e276560ffd3a1d017683259f52552fc7c2e5
-  libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
+  libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   Sentry: e92ec378be400dbb7f4065ff152d0f362ba8b4ba
@@ -86,6 +89,6 @@ SPEC CHECKSUMS:
   YatLib: dda2cfe9e47790f27a13074ea815eac19a919043
   Zip: b3fef584b147b6e582b2256a9815c897d60ddc67
 
-PODFILE CHECKSUM: 154a2c1d1be3da085e9e5637dba213d68731bf8b
+PODFILE CHECKSUM: 5073b4018cb44a74e569481a25dfad4f4cf98940
 
 COCOAPODS: 1.15.2

--- a/dependencies.env
+++ b/dependencies.env
@@ -1,1 +1,1 @@
-FFI_VERSION="1.11.0-rc.0"
+FFI_VERSION="1.13.0-rc.0"

--- a/dependencies.env
+++ b/dependencies.env
@@ -1,1 +1,1 @@
-FFI_VERSION="1.9.1-rc.0"
+FFI_VERSION="1.11.0-rc.0"


### PR DESCRIPTION
Set ffi lib version to 1.13.0-rc.0
Change min req version to 1.13.0-rc.0
Merge old hotfixes for: missing transaction note, wallet version verification
Merge old fixes: untapable text field in recover with passphrase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a long press gesture on token input areas that triggers a quick text editing menu.
- **Improvements**
	- Updated the app to version 0.31.3 with enhanced wallet version validation and streamlined transaction handling that consistently displays payment identifiers.
	- Streamlined one-sided payment processing by automatically enabling it and hiding redundant UI controls.
- **Dependencies**
	- Upgraded external libraries for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->